### PR TITLE
proxy - no timeout, check abi type

### DIFF
--- a/src/backend/proxy/proxy.ts
+++ b/src/backend/proxy/proxy.ts
@@ -63,6 +63,14 @@ app.post('/sendContract', async (req: RequestBody<TxnRequest>, res) => {
     return
   }
 
+  if (req.body.abi !== undefined && typeof req.body.abi !== 'object') {
+    res.status(500).send({
+      message: `Abi must be an object. Type ${typeof req.body
+        .abi} was sent instead.`
+    })
+    return
+  }
+
   // ensure abi is available and cached locally
   if (req.body.abi !== undefined) {
     // abi is defined so cache it
@@ -113,4 +121,5 @@ export const serverStarted = new Promise((resolve) => {
     console.log(`🚀 Ready at http://localhost:${port}`)
     resolve(1)
   })
+  server.setTimeout(0)
 })


### PR DESCRIPTION
This explicitly prevents timeout for the proxy server and checks the abi type if it's passed. In the event where the game dev sends a string instead of an object for abi, this will send an appropriate error message.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
