### PR TITLE
[OTHER] Close to tray and minimize on launch by default

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -580,7 +580,7 @@ class GlobalConfigV0 extends GlobalConfig {
       language: 'en',
       maxWorkers: 0,
       exitToTray: true,
-      minimizeOnLaunch: true,
+      minimizeOnGameLaunch: true,
       nvidiaPrime: false,
       enviromentOptions: [],
       wrapperOptions: [],

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -949,7 +949,7 @@ ipcMain.handle(
     const game = isSideloaded ? getAppInfo(appName) : extGame.getGameInfo()
     const { title } = game
 
-    const { minimizeOnLaunch } = await GlobalConfig.get().getSettings()
+    const { minimizeOnGameLaunch } = await GlobalConfig.get().getSettings()
 
     const startPlayingDate = new Date()
 
@@ -969,7 +969,7 @@ ipcMain.handle(
       status: 'playing'
     })
 
-    if (minimizeOnLaunch) {
+    if (minimizeOnGameLaunch) {
       mainWindow.hide()
     }
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -65,7 +65,7 @@ export interface AppSettings extends GameSettings {
   libraryTopSection: LibraryTopSectionOptions
   maxRecentGames: number
   maxWorkers: number
-  minimizeOnLaunch: boolean
+  minimizeOnGameLaunch: boolean
   startInTray: boolean
   userInfo: UserInfo
   defaultWinePrefix: string

--- a/src/frontend/screens/Settings/components/MinimizeOnGameLaunch.tsx
+++ b/src/frontend/screens/Settings/components/MinimizeOnGameLaunch.tsx
@@ -5,16 +5,16 @@ import useSetting from 'frontend/hooks/useSetting'
 
 const MinimizeOnGameLaunch = () => {
   const { t } = useTranslation()
-  const [minimizeOnLaunch, setMinimizeOnLaunch] = useSetting(
-    'minimizeOnLaunch',
+  const [minimizeOnGameLaunch, setMinimizeOnGameLaunch] = useSetting(
+    'minimizeOnGameLaunch',
     false
   )
 
   return (
     <ToggleSwitch
-      htmlId="minimizeOnLaunch"
-      value={minimizeOnLaunch}
-      handleChange={() => setMinimizeOnLaunch(!minimizeOnLaunch)}
+      htmlId="minimizeOnGameLaunchSwitch"
+      value={minimizeOnGameLaunch}
+      handleChange={() => setMinimizeOnGameLaunch(!minimizeOnGameLaunch)}
       title={t(
         'setting.minimize-on-launch',
         'Minimize HyperPlay After Game Launch'


### PR DESCRIPTION
Changed the default settings of HP to Close to Tray to `true` and also Minimze on Launch to `true` by default. 

This won't affect old configs unless you click on RESET HYPERPLAY on Advanced Settings.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
