### PR TITLE
allow yarn berry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ flatpak/build
 
 vite-plugin-electron.log
 .tool-versions
+
+# Yarn Berry support
+# these can be reconfigured if we ever want to adopt yarn berry
+.yarnrc.yml 
+.yarn/

--- a/package.json
+++ b/package.json
@@ -265,5 +265,6 @@
   },
   "optionalDependencies": {
     "@hyperplay/electron-overlay": "^0.0.8"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
I set up a new computer and installed yarn berry (yarn 2+) as my global yarn executable. I then set the version to yarn classic in the hyperplay-desktop-client repo and it added a line to package.json that informs the executable to use the last stable release of version 1. The .gitignore entries ignore the yarn berry specific items and we can change that in the future if we want to adopt latest versions of yarn. 
---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
