### PR TITLE
update documentation sidebar link

### DIFF
--- a/src/backend/constants.ts
+++ b/src/backend/constants.ts
@@ -72,7 +72,7 @@ const githubURL = 'https://github.com/G7DAO/HyperPlay/releases/latest'
 const GITHUB_API = 'https://api.github.com/repos/G7DAO/HyperPlay/releases'
 const supportURL = 'https://github.com/G7DAO/HyperPlay/blob/main/Support.md'
 const discordLink = 'https://discord.gg/Vx4ky6ZbAK'
-const wikiLink = 'https://github.com/G7DAO/HyperPlay/wiki'
+const wikiLink = 'https://docs.hyperplaygaming.com/'
 const weblateUrl =
   'https://hosted.weblate.org/projects/hyperplay-games-launcher'
 const wineprefixFAQ = 'https://wiki.winehq.org/FAQ#Wineprefixes'


### PR DESCRIPTION
Current link is a 404. Update from "https://github.com/G7DAO/HyperPlay/wiki" to "https://docs.hyperplaygaming.com", matching the docs link on hyperplay.xyz
