### PR TITLE
[Fix] macOS Intel Signing

### DIFF
--- a/.github/workflows/release_macOS.yml
+++ b/.github/workflows/release_macOS.yml
@@ -44,6 +44,6 @@ jobs:
         run: yarn
 
       - name: Build artifacts.
-        run: yarn release:mac --arm64
+        run: yarn release:mac
         env:
           NOTARIZE: true

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ flatpak/build
 
 vite-plugin-electron.log
 .tool-versions
+.env


### PR DESCRIPTION
Small fix.
During testing, I limited the release to only the arm64 build so I think for that reason the x64 was not being signed.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
