### PR TITLE
[Fix] Do not show Anti-cheat info for HP games

### DIFF
--- a/src/frontend/components/UI/Anticheat/index.tsx
+++ b/src/frontend/components/UI/Anticheat/index.tsx
@@ -17,13 +17,19 @@ export default function Anticheat({ gameInfo }: Props) {
   const [anticheatInfo, setAnticheatInfo] = useState<AntiCheatInfo | null>(null)
 
   useEffect(() => {
-    if (gameInfo.runner !== 'sideload' && gameInfo.title) {
-      window.api
-        .getAnticheatInfo(gameInfo.namespace)
-        .then((anticheatInfo: AntiCheatInfo | null) => {
-          setAnticheatInfo(anticheatInfo)
-        })
+    const antiCheatRunners = ['legendary', 'gog']
+    const shouldFetch =
+      antiCheatRunners.includes(gameInfo.runner) && gameInfo.title
+
+    if (!shouldFetch) {
+      return
     }
+    const info = gameInfo as GameInfo
+    window.api
+      .getAnticheatInfo(info.namespace)
+      .then((anticheatInfo: AntiCheatInfo | null) => {
+        setAnticheatInfo(anticheatInfo)
+      })
   }, [gameInfo])
 
   if (!anticheatInfo) {


### PR DESCRIPTION
Skip check for HP games.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
