### PR TITLE
feat: overhauled & animated extension popup and notification

### DIFF
--- a/src/frontend/ExtensionManager/index.module.scss
+++ b/src/frontend/ExtensionManager/index.module.scss
@@ -1,31 +1,30 @@
 .mmContainer {
+  // @include proportions;
+
   position: absolute;
-  left: 250px;
-  top: 10px;
+  right: 550px;
   display: flex;
   flex-direction: row;
   gap: 20px;
   z-index: 100000;
 }
 
-@mixin mmWindow {
-  width: 360px;
-  height: 620px;
-  position: relative;
+.mmWindow {
+  width: 357px;
+  height: 600px;
+  overflow: hidden;
+  border-radius: 0px 0px 16px 16px;
+  position: absolute;
   display: flex;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(-20px);
+  transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
+  box-shadow: rgb(0 0 0 / 35%) 0px 5px 15px;
 }
 
-.mmPopup {
-  @include mmWindow();
-}
-
-.mmNotification {
-  @include mmWindow();
-}
-
-.mmNotification {
-  width: 360px;
-  height: 620px;
-  position: relative;
-  display: flex;
+.open {
+  pointer-events: auto;
+  opacity: 1;
+  transform: translateY(0);
 }

--- a/src/frontend/components/UI/Sidebar/index.tsx
+++ b/src/frontend/components/UI/Sidebar/index.tsx
@@ -11,7 +11,9 @@ import ContextProvider from 'frontend/state/ContextProvider'
 import { t } from 'i18next'
 import { faAngleDown } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import extensionStore from 'frontend/store/ExtensionStore'
 import SidbarStyles from './index.module.scss'
+import { observable } from 'mobx'
 
 let sidebarSize = 240
 const localStorageSidebarWidth = localStorage.getItem('sidebar-width')
@@ -28,7 +30,6 @@ const Sidebar = observer(() => {
     useContext(ContextProvider)
   const [badgeText, setBadgeText] = useState('0')
   const [showMetaMaskSubMenu, setShowMetaMaskSubMenu] = useState(false)
-  const [metamaskPopupIsActive, setMetamaskPopupIsActive] = useState(false)
 
   /* eslint-disable-next-line  @typescript-eslint/no-explicit-any */
   function setBadgeString(err: any, text: string) {
@@ -167,13 +168,13 @@ const Sidebar = observer(() => {
                 <span>{t('metamask.sidebar.home', 'Home')}</span>
               </NavLink>
               <button
-                className={classNames('Sidebar__item SidebarLinks__subItem', {
-                  active: metamaskPopupIsActive
-                })}
-                onClick={async () => {
-                  const popupIsShown = await window.api.showPopup()
-                  setMetamaskPopupIsActive(popupIsShown)
-                }}
+                className={classNames(
+                  'Sidebar__item SidebarLinks__subItem SidebarLinks__subItem__popup',
+                  {
+                    active: extensionStore.isPopupOpen
+                  }
+                )}
+                onClick={() => extensionStore.toggleIsPopupOpen()}
               >
                 <span>{t('metamask.sidebar.popup', 'Popup')}</span>
               </button>
@@ -198,4 +199,4 @@ const Sidebar = observer(() => {
   )
 })
 
-export default React.memo(Sidebar)
+export default React.memo(observable(Sidebar))

--- a/src/frontend/store/ExtensionStore.ts
+++ b/src/frontend/store/ExtensionStore.ts
@@ -1,0 +1,63 @@
+import { makeAutoObservable } from 'mobx'
+
+class ExtensionStore {
+  extensionId = ''
+  isNotificationOpen = false
+  isPopupOpen = false
+
+  constructor() {
+    makeAutoObservable(this)
+
+    this.init()
+  }
+
+  init() {
+    this.fetchExtensionId()
+
+    window.api.handleShowNotificationInWebview(() => {
+      this.setIsNotificationOpen(true)
+
+      this.setIsPopupOpen(true)
+    })
+
+    window.api.handleRemoveNotificationInWebview(() => {
+      this.setIsNotificationOpen(false)
+
+      this.setIsPopupOpen(false)
+    })
+
+    window.api.handleShowPopupInWebview(() => {
+      this.setIsPopupOpen(true)
+    })
+
+    window.api.handleRemovePopupInWebview(() => {
+      this.setIsPopupOpen(false)
+    })
+  }
+
+  async fetchExtensionId() {
+    const extensionId = await window.api.getExtensionId()
+
+    this.extensionId = extensionId
+
+    return extensionId
+  }
+
+  setIsPopupOpen(isOpen: boolean) {
+    console.log(isOpen)
+
+    this.isPopupOpen = isOpen
+  }
+
+  toggleIsPopupOpen() {
+    this.setIsPopupOpen(!this.isPopupOpen)
+  }
+
+  private setIsNotificationOpen(isOpen: boolean) {
+    this.isNotificationOpen = isOpen
+  }
+}
+
+const extensionStore = new ExtensionStore()
+
+export default extensionStore

--- a/src/frontend/store/ExtensionStore.ts
+++ b/src/frontend/store/ExtensionStore.ts
@@ -44,8 +44,6 @@ class ExtensionStore {
   }
 
   setIsPopupOpen(isOpen: boolean) {
-    console.log(isOpen)
-
     this.isPopupOpen = isOpen
   }
 


### PR DESCRIPTION
* feat: clicking outside of popup closes the popup(if the clicked element isn't a webview)

* fix: 2 popups showing up at the same time

* fix: popup menuitem temporarily doesn't react to clicks

* fix: popup menuitem at times doesn't show whether the popup is open or not

A small store has been introduced that manages the popup open state, and arranges the communication between the sidebar & ExtensionManager. Having a single source of truth reduced complications and clarifies the logic as opposed to having this communication run through the backend.



---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
