### PR TITLE
[Tech] Watch library changes and commit them to GlobalState

### DIFF
--- a/src/backend/api/library.ts
+++ b/src/backend/api/library.ts
@@ -102,3 +102,16 @@ export const launchApp = async (
   appName: string,
   runner: 'hyperplay' | 'sideload'
 ): Promise<boolean> => ipcRenderer.invoke('launchApp', appName, runner)
+
+export const onLibraryChange = async (
+  callback: (
+    event: Electron.IpcRendererEvent,
+    runner: Runner,
+    newLibrary: GameInfo[]
+  ) => void
+) => {
+  ipcRenderer.on('onLibraryChanged', callback)
+  return () => {
+    ipcRenderer.removeListener('onLibraryChanged', callback)
+  }
+}

--- a/src/backend/electron_store.ts
+++ b/src/backend/electron_store.ts
@@ -50,6 +50,21 @@ export class TypeCheckedStoreBackend<
     this.store.delete(key)
   }
 
+  public onDidChange<KeyType extends string>(
+    key: KeyType,
+    callback: (
+      newVal?: UnknownGuard<Get<Structure, KeyType>>,
+      oldVal?: UnknownGuard<Get<Structure, KeyType>>
+    ) => void
+  ) {
+    this.store.onDidChange(key, (newVal, oldVal) => {
+      callback(
+        newVal as UnknownGuard<Get<Structure, KeyType>> | undefined,
+        oldVal as UnknownGuard<Get<Structure, KeyType>> | undefined
+      )
+    })
+  }
+
   public clear() {
     this.store.clear()
   }

--- a/src/backend/storeManagers/hyperplay/library.ts
+++ b/src/backend/storeManagers/hyperplay/library.ts
@@ -1,4 +1,3 @@
-import { sendFrontendMessage } from '../../main_window'
 import { hpLibraryStore } from './electronStore'
 import {
   CallRunnerOptions,
@@ -76,8 +75,6 @@ export async function addGameToLibrary(appId: string) {
   }
 
   hpLibraryStore.set('games', [...currentLibrary, gameInfo])
-
-  sendFrontendMessage('refreshLibrary', 'hyperplay')
 }
 
 export const getInstallInfo = async (

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -195,7 +195,6 @@ class GlobalState extends PureComponent<Props> {
 
   watchLibraryChanges() {
     window.api.onLibraryChange((_e, runner, newLibrary) => {
-      console.log('library changed', runner, newLibrary)
       if (runner === 'legendary') {
         this.setState({ epic: { ...this.state.epic, library: newLibrary } })
       } else if (runner === 'gog') {

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -197,9 +197,9 @@ class GlobalState extends PureComponent<Props> {
     window.api.onLibraryChange((_e, runner, newLibrary) => {
       console.log('library changed', runner, newLibrary)
       if (runner === 'legendary') {
-        this.setState({ epic: { library: newLibrary } })
+        this.setState({ epic: { ...this.state.epic, library: newLibrary } })
       } else if (runner === 'gog') {
-        this.setState({ gog: { library: newLibrary } })
+        this.setState({ gog: { ...this.state.gog, library: newLibrary } })
       } else if (runner === 'sideload') {
         this.setState({ sideloadedLibrary: newLibrary })
       } else if (runner === 'hyperplay') {

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -193,6 +193,21 @@ class GlobalState extends PureComponent<Props> {
     ) as MetricsOptInStatus
   }
 
+  watchLibraryChanges() {
+    window.api.onLibraryChange((_e, runner, newLibrary) => {
+      console.log('library changed', runner, newLibrary)
+      if (runner === 'legendary') {
+        this.setState({ epic: { library: newLibrary } })
+      } else if (runner === 'gog') {
+        this.setState({ gog: { library: newLibrary } })
+      } else if (runner === 'sideload') {
+        this.setState({ sideloadedLibrary: newLibrary })
+      } else if (runner === 'hyperplay') {
+        this.setState({ hyperPlayLibrary: newLibrary })
+      }
+    })
+  }
+
   setLanguage = (newLanguage: string) => {
     this.setState({ language: newLanguage })
   }
@@ -592,6 +607,8 @@ class GlobalState extends PureComponent<Props> {
   }
 
   async componentDidMount() {
+    this.watchLibraryChanges()
+
     const { t } = this.props
     const { epic, gameUpdates = [], libraryStatus, category } = this.state
     const oldCategory: string = category


### PR DESCRIPTION
Watches library changes from the backend and pushes those to the GlobalState.

This is a fix for the need to refresh the entire library when adding a HP game, and making that process instant.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
