### PR TITLE
[Fix] Import Folder

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -6,7 +6,7 @@
             "title": "Change Games Install Path"
         },
         "choose": "Choose",
-        "importpath": "Choose game executable to import",
+        "importpath": "Choose Game Folder to import",
         "move": {
             "message": "This can take a long time, are you sure?",
             "path": "Choose where you want to move",

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -12,7 +12,7 @@ import {
   getGameInfo as getGogLibraryGameInfo,
   changeGameInstallPath
 } from './library'
-import { join, dirname } from 'path'
+import { join } from 'path'
 import { GameConfig } from '../../game_config'
 import { GlobalConfig } from '../../config'
 import {
@@ -109,12 +109,12 @@ export async function getSettings(appName: string): Promise<GameSettings> {
 
 export async function importGame(
   appName: string,
-  executablePath: string,
+  folderPath: string,
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
   platform: InstallPlatform
 ): Promise<ExecResult> {
   const res = await runGogdlCommand(
-    ['import', dirname(executablePath)],
+    ['import', folderPath],
     createAbortController(appName),
     {
       logMessagePrefix: `Importing ${appName}`
@@ -133,7 +133,7 @@ export async function importGame(
   }
 
   try {
-    await importGogLibraryGame(JSON.parse(res.stdout), executablePath)
+    await importGogLibraryGame(JSON.parse(res.stdout), folderPath)
     addShortcuts(appName)
   } catch (error) {
     logError(['Failed to import', `${appName}:`, error], LogPrefix.Gog)

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -18,7 +18,7 @@ import {
   GamesDBData,
   Library
 } from 'common/types/gog'
-import { basename, dirname, join } from 'node:path'
+import { basename, join } from 'node:path'
 import { existsSync, readFileSync } from 'graceful-fs'
 
 import { logError, logInfo, LogPrefix, logWarning } from '../../logger/logger'
@@ -590,7 +590,7 @@ export async function importGame(data: GOGImportData, executablePath: string) {
 
   const installInfo: InstalledInfo = {
     appName: data.appName,
-    install_path: dirname(executablePath),
+    install_path: executablePath,
     executable: executablePath,
     install_size: getFileSize(gameInfo.manifest?.disk_size),
     is_dlc: false,

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -53,7 +53,7 @@ import {
   addShortcuts as addShortcutsUtil,
   removeShortcuts as removeShortcutsUtil
 } from '../../shortcuts/shortcuts/shortcuts'
-import { dirname, join } from 'path'
+import { join } from 'path'
 import { gameInfoStore } from './electronStores'
 import { removeNonSteamGame } from '../../shortcuts/nonesteamgame/nonesteamgame'
 import shlex from 'shlex'
@@ -691,7 +691,7 @@ export async function repair(appName: string): Promise<ExecResult> {
 
 export async function importGame(
   appName: string,
-  executablePath: string,
+  folderPath: string,
   platform: InstallPlatform
 ): Promise<ExecResult> {
   const commandParts = [
@@ -700,7 +700,7 @@ export async function importGame(
     '--platform',
     platform,
     appName,
-    dirname(executablePath)
+    folderPath
   ]
 
   logInfo(`Importing ${appName}.`, LogPrefix.Legendary)

--- a/src/frontend/helpers/library.ts
+++ b/src/frontend/helpers/library.ts
@@ -70,7 +70,7 @@ async function install({
       await window.api.requestAppSettings()
     const args: Electron.OpenDialogOptions = {
       buttonLabel: t('gamepage:box.choose'),
-      properties: ['openFile'],
+      properties: ['openDirectory'],
       title: t('gamepage:box.importpath'),
       defaultPath: defaultInstallPath
       //TODO: add file filters


### PR DESCRIPTION
Import directory is necessary for single file applications on mac so this reverts the previous change to import executable

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
