### PR TITLE
[Fix] Reload MetaMask on Open

### DIFF
--- a/src/frontend/ExtensionManager/index.tsx
+++ b/src/frontend/ExtensionManager/index.tsx
@@ -19,6 +19,17 @@ declare global {
 const ExtensionManager = function () {
   const rootRef = useRef<HTMLDivElement>(null)
   const popupRef = useRef<WebviewType>(null)
+  const notificationRef = useRef<WebviewType>(null)
+
+  useEffect(() => {
+    extensionStore.isPopupOpen &&
+      !extensionStore.isNotificationOpen &&
+      popupRef.current?.reload()
+
+    extensionStore.isPopupOpen &&
+      extensionStore.isNotificationOpen &&
+      notificationRef.current?.reload()
+  }, [extensionStore.isPopupOpen, extensionStore.isNotificationOpen])
 
   useEffect(() => {
     const handleOutsideClick = (e: MouseEvent) => {
@@ -47,29 +58,26 @@ const ExtensionManager = function () {
   /* eslint-disable react/no-unknown-property */
   return (
     <div className={ExtensionManagerStyles.mmContainer} ref={rootRef}>
-      {extensionStore.isPopupOpen ? (
-        <webview
-          ref={popupRef}
-          nodeintegrationinsubframes="true"
-          webpreferences="contextIsolation=true, nodeIntegration=true"
-          src={`chrome-extension://${extensionStore.extensionId}/popup.html`}
-          className={classNames(ExtensionManagerStyles.mmWindow, {
-            [ExtensionManagerStyles.open]:
-              extensionStore.isPopupOpen && !extensionStore.isNotificationOpen
-          })}
-        ></webview>
-      ) : null}
-      {extensionStore.isNotificationOpen ? (
-        <webview
-          nodeintegrationinsubframes="true"
-          webpreferences="contextIsolation=true, nodeIntegration=true"
-          src={`chrome-extension://${extensionStore.extensionId}/notification.html`}
-          className={classNames(ExtensionManagerStyles.mmWindow, {
-            [ExtensionManagerStyles.open]:
-              extensionStore.isPopupOpen && extensionStore.isNotificationOpen
-          })}
-        ></webview>
-      ) : null}
+      <webview
+        ref={popupRef}
+        nodeintegrationinsubframes="true"
+        webpreferences="contextIsolation=true, nodeIntegration=true"
+        src={`chrome-extension://${extensionStore.extensionId}/popup.html`}
+        className={classNames(ExtensionManagerStyles.mmWindow, {
+          [ExtensionManagerStyles.open]:
+            extensionStore.isPopupOpen && !extensionStore.isNotificationOpen
+        })}
+      ></webview>
+      <webview
+        ref={notificationRef}
+        nodeintegrationinsubframes="true"
+        webpreferences="contextIsolation=true, nodeIntegration=true"
+        src={`chrome-extension://${extensionStore.extensionId}/notification.html`}
+        className={classNames(ExtensionManagerStyles.mmWindow, {
+          [ExtensionManagerStyles.open]:
+            extensionStore.isPopupOpen && extensionStore.isNotificationOpen
+        })}
+      ></webview>
     </div>
   )
 }

--- a/src/frontend/ExtensionManager/index.tsx
+++ b/src/frontend/ExtensionManager/index.tsx
@@ -47,25 +47,29 @@ const ExtensionManager = function () {
   /* eslint-disable react/no-unknown-property */
   return (
     <div className={ExtensionManagerStyles.mmContainer} ref={rootRef}>
-      <webview
-        ref={popupRef}
-        nodeintegrationinsubframes="true"
-        webpreferences="contextIsolation=true, nodeIntegration=true"
-        src={`chrome-extension://${extensionStore.extensionId}/popup.html`}
-        className={classNames(ExtensionManagerStyles.mmWindow, {
-          [ExtensionManagerStyles.open]:
-            extensionStore.isPopupOpen && !extensionStore.isNotificationOpen
-        })}
-      ></webview>
-      <webview
-        nodeintegrationinsubframes="true"
-        webpreferences="contextIsolation=true, nodeIntegration=true"
-        src={`chrome-extension://${extensionStore.extensionId}/notification.html`}
-        className={classNames(ExtensionManagerStyles.mmWindow, {
-          [ExtensionManagerStyles.open]:
-            extensionStore.isPopupOpen && extensionStore.isNotificationOpen
-        })}
-      ></webview>
+      {extensionStore.isPopupOpen ? (
+        <webview
+          ref={popupRef}
+          nodeintegrationinsubframes="true"
+          webpreferences="contextIsolation=true, nodeIntegration=true"
+          src={`chrome-extension://${extensionStore.extensionId}/popup.html`}
+          className={classNames(ExtensionManagerStyles.mmWindow, {
+            [ExtensionManagerStyles.open]:
+              extensionStore.isPopupOpen && !extensionStore.isNotificationOpen
+          })}
+        ></webview>
+      ) : null}
+      {extensionStore.isNotificationOpen ? (
+        <webview
+          nodeintegrationinsubframes="true"
+          webpreferences="contextIsolation=true, nodeIntegration=true"
+          src={`chrome-extension://${extensionStore.extensionId}/notification.html`}
+          className={classNames(ExtensionManagerStyles.mmWindow, {
+            [ExtensionManagerStyles.open]:
+              extensionStore.isPopupOpen && extensionStore.isNotificationOpen
+          })}
+        ></webview>
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
This reloads MetaMask popup and notification windows on open for the main client renderer process.

This fixes the issue where you have to log into MetaMask twice (on the notification and then the popup screen).

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
