### PR TITLE
[Fix] Unhandled HP Store Exception

### DIFF
--- a/src/backend/storeManagers/hyperplay/library.ts
+++ b/src/backend/storeManagers/hyperplay/library.ts
@@ -214,6 +214,8 @@ export function getGameInfo(
 }
 
 export async function updateAllLibraryReleaseData() {
+  console.warn('updateAllLibraryReleaseData NOT IMPLEMENTED!')
+  return
   const allListingsResponse = await axios.get(
     'https://developers.hyperplay.xyz/api/listings'
   )
@@ -232,7 +234,6 @@ export async function updateAllLibraryReleaseData() {
   currentHpLibrary.map((localReleaseData, index) => {
     const remoteReleaseData = listingMap[localReleaseData.app_name]
     //copy remote data to local release data in library
-    throw 'ERROR updateAllLibraryReleaseData NOT IMPLEMENTED!'
   })
 }
 


### PR DESCRIPTION
Fixes an unhandled HyperPlay store manager exception for an unimplemented method

Removed and replaced with refresh in https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/pull/257
This could be causing crashes on launch so a separate PR was made

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
