### PR TITLE
[Fix] Fix eth_requestAccounts not executing after reloadApp event

### DIFF
--- a/src/frontend/ExtensionHandler/index.tsx
+++ b/src/frontend/ExtensionHandler/index.tsx
@@ -11,6 +11,7 @@ const ExtensionHandler = function () {
   ) {
     try {
       console.log('requesting from mm browser ext = ', JSON.stringify(args))
+      await waitForConnection()
       const value = await window.ethereum.request(args)
       window.api.returnExtensionRequest(id, value)
     } catch (err) {
@@ -25,6 +26,7 @@ const ExtensionHandler = function () {
 
   async function handleSend(event: Event, id: number, args: unknown[]) {
     try {
+      await waitForConnection()
       const value = await window.ethereum.send(...args)
       window.api.returnExtensionRequest(id, value)
     } catch (err) {
@@ -35,6 +37,7 @@ const ExtensionHandler = function () {
 
   async function handleSendAsync(event: Event, id: number, args: unknown[]) {
     try {
+      await waitForConnection()
       const value = await window.ethereum.sendAsync(...args)
       window.api.returnExtensionRequest(id, value)
     } catch (err) {
@@ -115,3 +118,15 @@ const ExtensionHandler = function () {
 }
 
 export default ExtensionHandler
+
+async function waitForConnection(): Promise<void> {
+  const isConnected = window.ethereum.isConnected()
+
+  if (isConnected) {
+    return
+  }
+
+  return new Promise((resolve) => {
+    window.ethereum.on('connect', resolve)
+  })
+}


### PR DESCRIPTION
When in devmode, the application is substantially slower with reloads, therefor this issue is only present in production builds.

Initial issue:
1. launch packaged version of HyperPlay
2. Import extension wallet
3. eth_requestAccounts doesn't get called properly, the wallet doesn't connect

In the above scenario, the MetaMask extension wasn't available yet to accept requests, thus this branch checks whether the connection has already been established, and if not, waits until it has been.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
