### PR TITLE
[Feat] Open browser game links with overlay, Make fullscreen

### DIFF
--- a/src/backend/storeManagers/sideload/games.ts
+++ b/src/backend/storeManagers/sideload/games.ts
@@ -67,51 +67,6 @@ export function isGameAvailable(appName: string): boolean {
   return false
 }
 
-if (Object.hasOwn(app, 'on'))
-  app.on('web-contents-created', (_, contents) => {
-    // Check for a webview
-    if (contents.getType() === 'webview') {
-      contents.setWindowOpenHandler(({ url }) => {
-        const protocol = new URL(url).protocol
-        if (['https:', 'http:'].includes(protocol)) {
-          openNewBrowserGameWindow(url)
-        }
-        return { action: 'deny' }
-      })
-    }
-  })
-
-const openNewBrowserGameWindow = async (
-  browserUrl: string
-): Promise<boolean> => {
-  return new Promise((res) => {
-    const browserGame = new BrowserWindow({
-      icon: icon,
-      webPreferences: {
-        webviewTag: true,
-        contextIsolation: true,
-        nodeIntegration: true,
-        preload: path.join(__dirname, 'preload.js')
-      }
-    })
-
-    const url = !app.isPackaged
-      ? 'http://localhost:5173?view=BrowserGame&browserUrl=' +
-        encodeURIComponent(browserUrl)
-      : `file://${path.join(
-          buildDir,
-          './index.html?view=BrowserGame&browserUrl=' +
-            encodeURIComponent(browserUrl)
-        )}`
-
-    browserGame.loadURL(url)
-    setTimeout(() => browserGame.focus(), 200)
-    browserGame.on('close', () => {
-      res(true)
-    })
-  })
-}
-
 export async function launch(
   appName: string,
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */

--- a/src/backend/storeManagers/sideload/games.ts
+++ b/src/backend/storeManagers/sideload/games.ts
@@ -8,10 +8,10 @@ import {
 } from 'common/types'
 import { libraryStore } from './electronStores'
 import { GameConfig } from '../../game_config'
-import { isWindows, isMac, isLinux, icon } from '../../constants'
+import { isWindows, isMac, isLinux } from '../../constants'
 import { killPattern } from '../../utils'
 import { logInfo, LogPrefix, logWarning } from '../../logger/logger'
-import path, { dirname, resolve } from 'path'
+import { dirname } from 'path'
 import { existsSync, rmSync } from 'graceful-fs'
 import i18next from 'i18next'
 import {
@@ -20,11 +20,9 @@ import {
 } from '../../shortcuts/shortcuts/shortcuts'
 import { notify } from '../../dialog/dialog'
 import { sendFrontendMessage } from '../../main_window'
-import { app, BrowserWindow } from 'electron'
 import { launchGame } from 'backend/storeManagers/storeManagerCommon/games'
 import { GOGCloudSavesLocation } from 'common/types/gog'
 import { InstallResult, RemoveArgs } from 'common/types/game_manager'
-const buildDir = resolve(__dirname, '../../build')
 
 export function getGameInfo(appName: string): GameInfo {
   const store = libraryStore.get('games', [])

--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -34,12 +34,40 @@ export function logFileLocation(appName: string) {
   return join(gamesConfigPath, `${appName}-lastPlay.log`)
 }
 
+const openRestrictedBrowserGameWindow = async (url: string) => {
+  const restrictedBrowserWindow = new BrowserWindow({
+    icon: icon,
+    webPreferences: {
+      webviewTag: true,
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true
+    }
+  })
+  restrictedBrowserWindow.loadURL(url)
+}
+
+function getDomainNameFromHostName(url: URL) {
+  const domainNameParts = url.hostname.split('.')
+  if (domainNameParts.length < 3) return url.hostname
+  return domainNameParts[1] + '.' + domainNameParts[2]
+}
+
+function domainsAreEqual(url: URL, otherUrl: URL) {
+  if (url.hostname === otherUrl.hostname) return true
+  const urlDomain = getDomainNameFromHostName(url)
+  const otherUrlDomain = getDomainNameFromHostName(otherUrl)
+  if (urlDomain === otherUrlDomain) return true
+  return false
+}
+
 const openNewBrowserGameWindow = async (
   browserUrl: string
 ): Promise<boolean> => {
   return new Promise((res) => {
     const browserGame = new BrowserWindow({
       icon: icon,
+      fullscreen: true,
       webPreferences: {
         webviewTag: true,
         contextIsolation: true,
@@ -57,10 +85,39 @@ const openNewBrowserGameWindow = async (
             encodeURIComponent(browserUrl)
         )}`
 
+    const urlParent = new URL(browserUrl)
+    const openNewBroswerGameWindowListener = (
+      ev: Electron.Event,
+      contents: Electron.WebContents
+    ) => {
+      // Check for a webview
+      if (contents.getType() === 'webview') {
+        contents.setWindowOpenHandler(({ url }) => {
+          const urlToOpen = new URL(url)
+          const protocol = urlToOpen.protocol
+
+          if (
+            ['https:', 'http:'].includes(protocol) &&
+            domainsAreEqual(urlToOpen, urlParent)
+          ) {
+            openNewBrowserGameWindow(url)
+            return { action: 'deny' }
+          }
+          openRestrictedBrowserGameWindow(url)
+          return { action: 'deny' }
+        })
+      }
+    }
+    app.on('web-contents-created', openNewBroswerGameWindowListener)
+
     browserGame.loadURL(url)
     setTimeout(() => browserGame.focus(), 200)
     browserGame.on('close', () => {
       res(true)
+      app.removeListener(
+        'web-contents-created',
+        openNewBroswerGameWindowListener
+      )
     })
   })
 }


### PR DESCRIPTION
Browser games with links that open new windows to different parts of their game now have the HyperPlay overlay available

Browser game windows default to fullscreen now

## Testing
1. Open defi kingdoms
2. Click Articles on the bulletin board. This does not open in full screen or with the overlay since domain (`medium.com`) does not match `defikingdoms.com`
3. Click on Tutorials on the bulletin board. This window has the same domain name `defikingdoms.com` so overlay is injected. If you click start playing, `game.defikingoms.com` will open in a new window which also has the overlay since the domains match

If you exit out of the bulletin board, you can get it back by clicking in the top right menu button, then click Bulletin Board at the top.

Bulletin board with test actions identified with the red pen marks:
<img width="1284" alt="image" src="https://user-images.githubusercontent.com/27568879/231611812-da34afeb-743f-499b-af0a-69433def6804.png">


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
