### PR TITLE
[Fix] HP Store Manager

### DIFF
--- a/src/backend/storeManagers/hyperplay/games.ts
+++ b/src/backend/storeManagers/hyperplay/games.ts
@@ -254,7 +254,7 @@ export async function install(
     return { status: 'error', error: 'Release meta not found' }
   }
 
-  logInfo(`Installing ${title} to ${path}...`, LogPrefix.HyperPlay)
+  logInfo(`Installing ${title} to ${dirpath}...`, LogPrefix.HyperPlay)
 
   // download the zip file
   try {

--- a/src/backend/storeManagers/hyperplay/games.ts
+++ b/src/backend/storeManagers/hyperplay/games.ts
@@ -404,6 +404,7 @@ export async function uninstall({
 
   // remove game folder from install path
   const installPath = appInfo.install.install_path
+  logInfo(`Removing folder in uninstall: ${installPath}`, LogPrefix.HyperPlay)
   rmSync(installPath, { recursive: true, force: true })
 
   // only remove the game from the store if the platform is web
@@ -425,12 +426,13 @@ export async function uninstall({
     (value) => value.app_name === appName
   )
   currentLibrary[gameIndex].is_installed = false
+  currentLibrary[gameIndex].install = {}
   hpLibraryStore.set('games', currentLibrary)
 
   if (shouldRemovePrefix) {
     const { winePrefix } = await getSettings(appName)
 
-    logInfo(`Removing prefix ${winePrefix}`, LogPrefix.Backend)
+    logInfo(`Removing prefix ${winePrefix}`, LogPrefix.HyperPlay)
     if (existsSync(winePrefix)) {
       // remove prefix if exists
       rmSync(winePrefix, { recursive: true })
@@ -483,7 +485,7 @@ export async function update(appName: string): Promise<InstallResult> {
   if (gameInfo.install.platform === undefined) {
     logError(
       'Install platform was not found during game updated',
-      LogPrefix.Backend
+      LogPrefix.HyperPlay
     )
     return { status: 'error' }
   }
@@ -491,14 +493,14 @@ export async function update(appName: string): Promise<InstallResult> {
   if (gameInfo.install.install_path === undefined) {
     logError(
       'Install path was not found during game updated',
-      LogPrefix.Backend
+      LogPrefix.HyperPlay
     )
     return { status: 'error' }
   }
 
   await uninstall({ appName })
   const installResult = await install(appName, {
-    path: gameInfo.install.install_path,
+    path: path.dirname(gameInfo.install.install_path),
     platformToInstall: gameInfo.install.platform
   })
   return installResult

--- a/src/backend/storeManagers/hyperplay/library.ts
+++ b/src/backend/storeManagers/hyperplay/library.ts
@@ -219,7 +219,6 @@ export function getGameInfo(
  * since library release data is updated on each app launch
  */
 export async function listUpdateableGames(): Promise<string[]> {
-  logWarning(`listUpdateableGames not implemented on HyperPlay Library Manager`)
   const allListingsResponse = await axios.get(
     'https://developers.hyperplay.xyz/api/listings'
   )
@@ -236,14 +235,17 @@ export async function listUpdateableGames(): Promise<string[]> {
   const updateableGames: string[] = []
   const currentHpLibrary = hpLibraryStore.get('games', [])
   currentHpLibrary.map((val) => {
-    if (val.install.platform === 'web') {
+    if (
+      val.install.platform === 'web' ||
+      !val.is_installed ||
+      !gameIsInstalled(val)
+    ) {
       return
     }
     if (val.version === undefined) {
       updateableGames.push(val.app_name)
     }
     if (
-      gameIsInstalled(val) &&
       Object.hasOwn(listingMap, val.app_name) &&
       val.install.version !== listingMap[val.app_name].releaseName
     ) {

--- a/src/backend/storeManagers/hyperplay/library.ts
+++ b/src/backend/storeManagers/hyperplay/library.ts
@@ -244,6 +244,7 @@ export async function listUpdateableGames(): Promise<string[]> {
     }
     if (
       gameIsInstalled(val) &&
+      Object.hasOwn(listingMap, val.app_name) &&
       val.install.version !== listingMap[val.app_name].releaseName
     ) {
       updateableGames.push(val.app_name)


### PR DESCRIPTION
Fixes
1. Uninstalled games auto updating
2. Delisted store games preventing `listUpdateableGames` from working
3. Recursive folder structure during updates

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
