### PR TITLE
[Proxy] Support Struct Params

### DIFF
--- a/src/backend/__mocks__/electron.ts
+++ b/src/backend/__mocks__/electron.ts
@@ -105,7 +105,8 @@ class Tray {
 const ipcMain = {
   on: jest.fn().mockReturnThis(),
   handle: jest.fn().mockReturnThis(),
-  once: jest.fn().mockReturnThis()
+  once: jest.fn().mockReturnThis(),
+  emit: jest.fn().mockReturnThis()
 }
 
 export {

--- a/src/backend/__mocks__/providerCallbacks.ts
+++ b/src/backend/__mocks__/providerCallbacks.ts
@@ -18,6 +18,7 @@ export function walletDisconnected(code: number, reason: string) {
 
 export function accountsChanged(accounts: string[]) {
   console.log('renderer receives: accounts changed to ', accounts)
+  connectedResolve()
 }
 
 export function chainChanged(chainId: number) {


### PR DESCRIPTION
Struct params passed are passed from web3.unreal as strings. This PR parses these strings if the corresponding ABI type is a tuple.

To test, run this curl command in a bash terminal while hyperplay is running
```
curl --location --request POST "localhost:9680/sendContract" \
--header 'Content-Type: application/json' \
--data-raw '{
    "contractAddress": "0x2e0cb17ed5f24bfcbb30d61e195d90e06e388e1e",
    "functionName": "setWeapon",
    "params": ["1","[\"rifle\", \"2\", \"4\", \"3\"]"],
    "valueInWei": "0",
    "chain": {
        "chainId": "5"
    }
}'
```

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
