### PR TITLE
[Feat] Auto Download Wine if no version was found in the system

### DIFF
--- a/public/locales/az/gamepage.json
+++ b/public/locales/az/gamepage.json
@@ -147,7 +147,7 @@
         "title": "Quraşdırılacaq komponentləri seçin"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/be/gamepage.json
+++ b/public/locales/be/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Выберыце кампаненты для ўстаноўкі"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/be/translation.json
+++ b/public/locales/be/translation.json
@@ -632,9 +632,9 @@
     "wine": {
         "actions": "Action",
         "manager": {
-            "link": "Wine Manager",
+            "link": "Compatibility Layer Manager",
             "not-found": "No Wine versions found. Please click the refresh icon to try again.",
-            "title": "Wine Manager (Beta)",
+            "title": "Compatibility Layer Manager (Beta)",
             "unzipping": "Unzipping"
         },
         "release": "Release Date",

--- a/public/locales/bg/gamepage.json
+++ b/public/locales/bg/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Изберете компоненти за инсталиране"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/bs/gamepage.json
+++ b/public/locales/bs/gamepage.json
@@ -147,7 +147,7 @@
         "title": "Odaberite komponente za instalaciju"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/ca/gamepage.json
+++ b/public/locales/ca/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Selecciona els components a instal·lar"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/cs/gamepage.json
+++ b/public/locales/cs/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Vyberte součásti k instalaci"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/de/gamepage.json
+++ b/public/locales/de/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Zu installierende Komponenten auswählen"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/el/gamepage.json
+++ b/public/locales/el/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Διαλέξτε στοιχεία για εγκατάσταση"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -149,7 +149,7 @@
         "title": "Select components to Install"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings",
+        "use-default-wine-settings": "Use Default Compatibility Settings",
         "winecrossoverbottle": "CrossOver Bottle"
     },
     "sideload": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -767,9 +767,9 @@
     "wine": {
         "actions": "Action",
         "manager": {
-            "link": "Wine Manager",
+            "link": "Compatibility Layer Manager",
             "not-found": "No Wine versions found. Please click the refresh icon to try again.",
-            "title": "Wine Manager",
+            "title": "Compatibility Layer Manager",
             "unzipping": "Unzipping"
         },
         "release": "Release Date",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -409,6 +409,7 @@
         "warning": "Warning",
         "wine-path": "Wine Path",
         "wine-path-invalid": "Wine Path is invalid, please select another one.",
+        "wine-path-none-found": "No Wine version was found, download one from the Compatibility Manager",
         "wine-prefix": {
             "title": "Wine Prefix"
         },

--- a/public/locales/es/gamepage.json
+++ b/public/locales/es/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Elija componentes a instalar"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/et/gamepage.json
+++ b/public/locales/et/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Valige komponendid, mida installida"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/eu/gamepage.json
+++ b/public/locales/eu/gamepage.json
@@ -147,7 +147,7 @@
         "title": "Instalatzeko osagaiak hautatzea"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/fa/gamepage.json
+++ b/public/locales/fa/gamepage.json
@@ -146,7 +146,7 @@
         "title": "انتخاب محتواها برای نصب"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/fi/gamepage.json
+++ b/public/locales/fi/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Valitse asennettavat komponentit"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -632,9 +632,9 @@
     "wine": {
         "actions": "Action",
         "manager": {
-            "link": "Wine Manageri",
+            "link": "Compatibility Layer Manageri",
             "not-found": "No Wine versions found. Please click the refresh icon to try again.",
-            "title": "Wine Manageri",
+            "title": "Compatibility Layer Manageri",
             "unzipping": "Purkaminen"
         },
         "release": "Release Date",

--- a/public/locales/gl/gamepage.json
+++ b/public/locales/gl/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Seleccione os compoñentes a instalar"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -632,9 +632,9 @@
     "wine": {
         "actions": "Action",
         "manager": {
-            "link": "Wine Manager",
+            "link": "Compatibility Layer Manager",
             "not-found": "No Wine versions found. Please click the refresh icon to try again.",
-            "title": "Wine Manager",
+            "title": "Compatibility Layer Manager",
             "unzipping": "Unzipping"
         },
         "release": "Release Date",

--- a/public/locales/hr/gamepage.json
+++ b/public/locales/hr/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Odaberite komponente za instalaciju"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -632,9 +632,9 @@
     "wine": {
         "actions": "Action",
         "manager": {
-            "link": "Wine Manager",
+            "link": "Compatibility Layer Manager",
             "not-found": "No Wine versions found. Please click the refresh icon to try again.",
-            "title": "Wine Manager",
+            "title": "Compatibility Layer Manager",
             "unzipping": "Unzipping"
         },
         "release": "Release Date",

--- a/public/locales/hu/gamepage.json
+++ b/public/locales/hu/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Válaszd ki a telepíteni kívánt elemeket"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/id/gamepage.json
+++ b/public/locales/id/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Pilih komponen untuk dipasang"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/it/gamepage.json
+++ b/public/locales/it/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Seleziona i componenti da installare"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -633,9 +633,9 @@
     "wine": {
         "actions": "Action",
         "manager": {
-            "link": "Wine Manager",
+            "link": "Compatibility Layer Manager",
             "not-found": "No Wine versions found. Please click the refresh icon to try again.",
-            "title": "Wine Manager",
+            "title": "Compatibility Layer Manager",
             "unzipping": "Unzipping"
         },
         "release": "Release Date",

--- a/public/locales/ja/gamepage.json
+++ b/public/locales/ja/gamepage.json
@@ -146,7 +146,7 @@
         "title": "インストールするコンポーネントを選択します"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -632,9 +632,9 @@
     "wine": {
         "actions": "Action",
         "manager": {
-            "link": "Wine Manager",
+            "link": "Compatibility Layer Manager",
             "not-found": "No Wine versions found. Please click the refresh icon to try again.",
-            "title": "Wine Manager",
+            "title": "Compatibility Layer Manager",
             "unzipping": "Unzipping"
         },
         "release": "Release Date",

--- a/public/locales/ml/gamepage.json
+++ b/public/locales/ml/gamepage.json
@@ -146,7 +146,7 @@
         "title": "നടുവാനുള്ള ഘടകങ്ങള് തിരഞ്ഞെടുക്കൂ"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -632,9 +632,9 @@
     "wine": {
         "actions": "Action",
         "manager": {
-            "link": "Wine Manager",
+            "link": "Compatibility Layer Manager",
             "not-found": "No Wine versions found. Please click the refresh icon to try again.",
-            "title": "Wine Manager",
+            "title": "Compatibility Layer Manager",
             "unzipping": "Unzipping"
         },
         "release": "Release Date",

--- a/public/locales/nb_NO/gamepage.json
+++ b/public/locales/nb_NO/gamepage.json
@@ -147,7 +147,7 @@
         "title": "Velg komponenter som skal installeres"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/nl/gamepage.json
+++ b/public/locales/nl/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Selecteer componenten om te installeren"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -632,9 +632,9 @@
     "wine": {
         "actions": "Action",
         "manager": {
-            "link": "Wine Manager",
+            "link": "Compatibility Layer Manager",
             "not-found": "No Wine versions found. Please click the refresh icon to try again.",
-            "title": "Wine Manager",
+            "title": "Compatibility Layer Manager",
             "unzipping": "Unzipping"
         },
         "release": "Release Date",

--- a/public/locales/pl/gamepage.json
+++ b/public/locales/pl/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Wybierz komponenty do instalacji"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/pt/gamepage.json
+++ b/public/locales/pt/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Selecione os componentes para instalar"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -632,9 +632,9 @@
     "wine": {
         "actions": "Action",
         "manager": {
-            "link": "Wine Manager",
+            "link": "Compatibility Layer Manager",
             "not-found": "No Wine versions found. Please click the refresh icon to try again.",
-            "title": "Wine Manager",
+            "title": "Compatibility Layer Manager",
             "unzipping": "Unzipping"
         },
         "release": "Release Date",

--- a/public/locales/pt_BR/gamepage.json
+++ b/public/locales/pt_BR/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Selecione os componentes para instalar"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/ro/gamepage.json
+++ b/public/locales/ro/gamepage.json
@@ -147,7 +147,7 @@
         "title": "Selectați componentele de instalat"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/ru/gamepage.json
+++ b/public/locales/ru/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Выбрать компоненты для установки"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/sk/gamepage.json
+++ b/public/locales/sk/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Vyberte komponenty na inštaláciu"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/sk/translation.json
+++ b/public/locales/sk/translation.json
@@ -632,9 +632,9 @@
     "wine": {
         "actions": "Action",
         "manager": {
-            "link": "Wine Manager",
+            "link": "Compatibility Layer Manager",
             "not-found": "No Wine versions found. Please click the refresh icon to try again.",
-            "title": "Wine Manager (Beta)",
+            "title": "Compatibility Layer Manager (Beta)",
             "unzipping": "Unzipping"
         },
         "release": "Release Date",

--- a/public/locales/ta/gamepage.json
+++ b/public/locales/ta/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Select components to Install"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -632,9 +632,9 @@
     "wine": {
         "actions": "Action",
         "manager": {
-            "link": "Wine Manager",
+            "link": "Compatibility Layer Manager",
             "not-found": "No Wine versions found. Please click the refresh icon to try again.",
-            "title": "Wine Manager",
+            "title": "Compatibility Layer Manager",
             "unzipping": "Unzipping"
         },
         "release": "Release Date",

--- a/public/locales/tr/gamepage.json
+++ b/public/locales/tr/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Kurulacak bileşenleri seç"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/uk/gamepage.json
+++ b/public/locales/uk/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Оберіть компоненти для встановлення"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/vi/gamepage.json
+++ b/public/locales/vi/gamepage.json
@@ -146,7 +146,7 @@
         "title": "Chọn các thành phần cần cài"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/zh_Hans/gamepage.json
+++ b/public/locales/zh_Hans/gamepage.json
@@ -146,7 +146,7 @@
         "title": "选择要安装的组件"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/zh_Hant/gamepage.json
+++ b/public/locales/zh_Hant/gamepage.json
@@ -146,7 +146,7 @@
         "title": "選擇要安裝的元件"
     },
     "setting": {
-        "use-default-wine-settings": "Use Default Wine Settings"
+        "use-default-wine-settings": "Use Default Compatibility Settings"
     },
     "sideload": {
         "field": {

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -10,7 +10,9 @@ import {
   SteamRuntime,
   Release,
   GameInfo,
-  GameSettings
+  GameSettings,
+  State,
+  ProgressInfo
 } from 'common/types'
 import axios, { AxiosResponse } from 'axios'
 import {
@@ -48,7 +50,8 @@ import {
   isWindows,
   publicDir,
   isMac,
-  configStore
+  configStore,
+  isLinux
 } from './constants'
 import { logError, logInfo, LogPrefix, logWarning } from './logger/logger'
 import { basename, dirname, join, normalize } from 'path'
@@ -72,6 +75,11 @@ import { GlobalConfig } from './config'
 import { GameConfig } from './game_config'
 import { validWine } from './launcher'
 import { gameManagerMap } from 'backend/storeManagers'
+import {
+  installWineVersion,
+  updateWineVersionInfos,
+  wineDownloaderInfoStore
+} from './wine/manager/utils'
 
 const execAsync = promisify(exec)
 
@@ -945,6 +953,39 @@ export async function checkWineBeforeLaunch(
       const firstFoundWine = wineList[0]
 
       const isValidWine = await validWine(firstFoundWine)
+
+      if (!wineList.length || !firstFoundWine || !isValidWine) {
+        // refresh wine list
+        await updateWineVersionInfos(true)
+        // get list of wines on wineDownloaderInfoStore
+        const availableWine = wineDownloaderInfoStore.get('wine-releases', [])
+        // use Wine-GE type if on Linux and Wine-Crossover if on Mac
+        const release = availableWine.filter(
+          (version) => version.type === (isLinux ? 'Wine-GE' : 'Wine-Crossover')
+        )[0]
+        // download the latest version
+        const onProgress = (state: State, progress?: ProgressInfo) => {
+          sendFrontendMessage('progressOfWineManager' + release.version, {
+            state,
+            progress
+          })
+        }
+        const result = await installWineVersion(
+          release,
+          onProgress,
+          createAbortController(release.version).signal
+        )
+        deleteAbortController(release.version)
+        if (result === 'success') {
+          const wineList = await GlobalConfig.get().getAlternativeWine()
+          // update the game config to use that wine
+          const firstFoundWine = wineList[0]
+          logInfo(`Changing wine version to ${firstFoundWine.name}`)
+          gameSettings.wineVersion = defaultwine
+          GameConfig.get(appName).setSetting('wineVersion', firstFoundWine)
+        }
+      }
+
       if (firstFoundWine && isValidWine) {
         const { response } = await ContinueWithFoundWine(
           gameSettings.wineVersion.name,

--- a/src/backend/wine/manager/utils.ts
+++ b/src/backend/wine/manager/utils.ts
@@ -18,7 +18,7 @@ import { toolsPath, isMac } from '../../constants'
 import { sendFrontendMessage } from '../../main_window'
 import { TypeCheckedStoreBackend } from 'backend/electron_store'
 
-const wineDownloaderInfoStore = new TypeCheckedStoreBackend(
+export const wineDownloaderInfoStore = new TypeCheckedStoreBackend(
   'wineDownloaderInfoStore',
   {
     cwd: 'store',

--- a/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
+++ b/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
@@ -298,10 +298,10 @@ export default function SidebarLinks() {
             <div className="Sidebar__itemIcon">
               <FontAwesomeIcon
                 icon={faWineGlass}
-                title={t('wine.manager.link', 'Wine Manager')}
+                title={t('wine.manager.link', 'Compatibility Layer Manager')}
               />
             </div>
-            <span>{t('wine.manager.link', 'Wine Manager')}</span>
+            <span>{t('wine.manager.link', 'Compatibility Layer Manager')}</span>
           </>
         </NavLink>
       )}

--- a/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
@@ -81,7 +81,7 @@ export default function WineSelector({
         htmlId="use-wine-defaults"
         title={t(
           'setting.use-default-wine-settings',
-          'Use Default Wine Settings'
+          'Use Default Compatibility Settings'
         )}
         value={useDefaultSettings}
         handleChange={() => setUseDefaultSettings(!useDefaultSettings)}

--- a/src/frontend/screens/Settings/components/WineVersionSelector.tsx
+++ b/src/frontend/screens/Settings/components/WineVersionSelector.tsx
@@ -5,6 +5,7 @@ import ContextProvider from 'frontend/state/ContextProvider'
 import { WineInstallation } from 'common/types'
 import useSetting from 'frontend/hooks/useSetting'
 import { defaultWineVersion } from '..'
+import { Link } from 'react-router-dom'
 
 export default function WineVersionSelector() {
   const { t } = useTranslation()
@@ -17,15 +18,18 @@ export default function WineVersionSelector() {
   )
   const [altWine, setAltWine] = useState<WineInstallation[]>([])
   const [validWine, setValidWine] = useState(true)
+  const [refreshing, setRefreshing] = useState(true)
 
   useEffect(() => {
     const getAltWine = async () => {
+      setRefreshing(true)
       const wineList: WineInstallation[] = await window.api.getAlternativeWine()
       setAltWine(wineList)
       // Avoids not updating wine config when having one wine install only
       if (wineList && wineList.length === 1) {
         setWineVersion(wineList[0])
       }
+      setRefreshing(false)
     }
     getAltWine()
   }, [])
@@ -57,7 +61,15 @@ export default function WineVersionSelector() {
       value={wineVersion.name}
       afterSelect={
         <>
-          {!validWine && (
+          {!refreshing && !altWine.length && (
+            <Link to={'/wine-manager'} className="smallInputInfo danger">
+              {t(
+                'infobox.wine-path-none-found',
+                'No Wine version was found, download one from the Compatibility Manager'
+              )}
+            </Link>
+          )}
+          {!!altWine.length && !validWine && (
             <span className="smallInputInfo danger">
               {t(
                 'infobox.wine-path-invalid',

--- a/src/frontend/screens/WineManager/index.tsx
+++ b/src/frontend/screens/WineManager/index.tsx
@@ -70,7 +70,7 @@ export default React.memo(function WineManager(): JSX.Element | null {
 
   // Track the screen view once
   useEffect(() => {
-    window.api.trackScreen('Wine Manager')
+    window.api.trackScreen('Compatibility Layer Manager')
   }, [])
 
   useEffect(() => {
@@ -94,7 +94,7 @@ export default React.memo(function WineManager(): JSX.Element | null {
   return (
     <>
       <h4 style={{ paddingTop: 'var(--space-md)' }}>
-        {t('wine.manager.title', 'Wine Manager (Beta)')}
+        {t('wine.manager.title', 'Compatibility Layer Manager (Beta)')}
       </h4>
       <div className="wineManager">
         <span className="tabsWrapper">


### PR DESCRIPTION
This will help new setups on mac and linux that does not have wine installed in their systems to play windows games.
If checks for any available wine on launch, if none was found, will download the recommended version: Wine-GE on Linux and Wine-Crossover on macOS. And then try to launch the game again.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
