### PR TITLE
[FIX] Auto Download Wine on macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperplay",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "main": "build/electron/main.js",
   "homepage": "./",

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -930,9 +930,11 @@ export async function downloadDefaultWine() {
   // use Wine-GE type if on Linux and Wine-Crossover if on Mac
   const release = availableWine.filter((version) => {
     if (isLinux) {
-      return version.version.includes('Wine-GE-Proton')
+      return (
+        version.type === 'Wine-GE' && version.version.includes('Wine-GE-Proton')
+      )
     } else if (isMac) {
-      return version.version.includes('Wine-Crossover')
+      return version.type === 'Wine-Crossover'
     }
     return false
   })[0]

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -928,11 +928,14 @@ export async function downloadDefaultWine() {
   // get list of wines on wineDownloaderInfoStore
   const availableWine = wineDownloaderInfoStore.get('wine-releases', [])
   // use Wine-GE type if on Linux and Wine-Crossover if on Mac
-  const release = availableWine.filter(
-    (version) =>
-      version.type === (isLinux ? 'Wine-GE' : 'Wine-Crossover') &&
-      version.version.includes('Wine-GE-Proton')
-  )[0]
+  const release = availableWine.filter((version) => {
+    if (isLinux) {
+      return version.version.includes('Wine-GE-Proton')
+    } else if (isMac) {
+      return version.version.includes('Wine-Crossover')
+    }
+    return false
+  })[0]
   // download the latest version
   const onProgress = (state: State, progress?: ProgressInfo) => {
     sendFrontendMessage('progressOfWineManager' + release.version, {

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -936,6 +936,12 @@ export async function downloadDefaultWine() {
     }
     return false
   })[0]
+
+  if (!release) {
+    logError('Could not find default wine version', LogPrefix.Backend)
+    return null
+  }
+
   // download the latest version
   const onProgress = (state: State, progress?: ProgressInfo) => {
     sendFrontendMessage('progressOfWineManager' + release.version, {
@@ -950,11 +956,19 @@ export async function downloadDefaultWine() {
   )
   deleteAbortController(release.version)
   if (result === 'success') {
-    const wineList = await GlobalConfig.get().getAlternativeWine()
-    // update the game config to use that wine
-    const downloadedWine = wineList[0]
-    logInfo(`Changing wine version to ${downloadedWine.name}`)
-    GlobalConfig.get().setSetting('wineVersion', downloadedWine)
+    let downloadedWine = null
+    try {
+      const wineList = await GlobalConfig.get().getAlternativeWine()
+      // update the game config to use that wine
+      downloadedWine = wineList[0]
+      logInfo(`Changing wine version to ${downloadedWine.name}`)
+      GlobalConfig.get().setSetting('wineVersion', downloadedWine)
+    } catch (error) {
+      logError(
+        ['Error when changing wine version to default', error],
+        LogPrefix.Backend
+      )
+    }
     return downloadedWine
   }
   return null


### PR DESCRIPTION
Noticed this small bug after merging the PR.

With the current filter it won't find anything on macOS since it will try to find Wine-GE for it but it does not exists.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
