### PR TITLE
Support HyperPlay Store Games Hosted on Epic

### DIFF
--- a/src/backend/__tests__/utils.test.ts
+++ b/src/backend/__tests__/utils.test.ts
@@ -60,9 +60,21 @@ describe('backend/utils.ts', () => {
   })
 
   test('test getting epic games title from url', () => {
-    expect(utils.getTitleFromEpicStoreUrl('https://store.epicgames.com/en-US/p/fall-guys')).toEqual('fall-guys')
-    expect(utils.getTitleFromEpicStoreUrl('https://www.epicgames.com/store/product/tear-of-time-lost-memory-add761')).toEqual('tear-of-time-lost-memory-add761')
-    expect(utils.getTitleFromEpicStoreUrl('https://store.epicgames.com/en-US/p/fortnite')).toEqual('fortnite')
+    expect(
+      utils.getTitleFromEpicStoreUrl(
+        'https://store.epicgames.com/en-US/p/fall-guys'
+      )
+    ).toEqual('fall-guys')
+    expect(
+      utils.getTitleFromEpicStoreUrl(
+        'https://www.epicgames.com/store/product/tear-of-time-lost-memory-add761'
+      )
+    ).toEqual('tear-of-time-lost-memory-add761')
+    expect(
+      utils.getTitleFromEpicStoreUrl(
+        'https://store.epicgames.com/en-US/p/fortnite'
+      )
+    ).toEqual('fortnite')
   })
 
   describe('getLatestReleases', () => {

--- a/src/backend/__tests__/utils.test.ts
+++ b/src/backend/__tests__/utils.test.ts
@@ -59,6 +59,12 @@ describe('backend/utils.ts', () => {
     })
   })
 
+  test('test getting epic games title from url', () => {
+    expect(utils.getTitleFromEpicStoreUrl('https://store.epicgames.com/en-US/p/fall-guys')).toEqual('fall-guys')
+    expect(utils.getTitleFromEpicStoreUrl('https://www.epicgames.com/store/product/tear-of-time-lost-memory-add761')).toEqual('tear-of-time-lost-memory-add761')
+    expect(utils.getTitleFromEpicStoreUrl('https://store.epicgames.com/en-US/p/fortnite')).toEqual('fortnite')
+  })
+
   describe('getLatestReleases', () => {
     test('Simple version', async () => {
       jest.spyOn(axios, 'get').mockResolvedValue(test_data)

--- a/src/backend/api/misc.ts
+++ b/src/backend/api/misc.ts
@@ -145,3 +145,12 @@ export const storeGet = (
 
 export const getWikiGameInfo = async (title: string, id?: string) =>
   ipcRenderer.invoke('getWikiGameInfo', title, id)
+
+export const handleNavToEpicAndOpen = (
+  onMessage: (e: Electron.IpcRendererEvent, url: string) => void
+): (() => void) => {
+  ipcRenderer.on('navToEpicAndOpenGame', onMessage)
+  return () => {
+    ipcRenderer.removeListener('navToEpicAndOpenGame', onMessage)
+  }
+}

--- a/src/backend/hyperplay_store_preload.ts
+++ b/src/backend/hyperplay_store_preload.ts
@@ -12,5 +12,7 @@ contextBridge.exposeInMainWorld('api', {
   isHidden: async (gameId: string) =>
     ipcRenderer.invoke('isGameHidden', gameId),
   unhide: async (gameId: string) => ipcRenderer.invoke('unhideGame', gameId),
-  openExternalUrl: (url: string) => ipcRenderer.send('openExternalUrl', url)
+  openExternalUrl: (url: string) => ipcRenderer.send('openExternalUrl', url),
+  openGameInEpicStore: (url: string) =>
+    ipcRenderer.send('openGameInEpicStore', url)
 })

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1868,5 +1868,6 @@ function watchLibraryChanges() {
 }
 
 ipcMain.on('openGameInEpicStore', async (_e, url) => {
-  sendFrontendMessage('navToEpicAndOpenGame', url)
+  if (url.startsWith('https://store.epicgames.com/'))
+    sendFrontendMessage('navToEpicAndOpenGame', url)
 })

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1866,3 +1866,7 @@ function watchLibraryChanges() {
     sendFrontendMessage('onLibraryChanged', 'hyperplay', newValue)
   )
 }
+
+ipcMain.on('openGameInEpicStore', async (_e, url) => {
+  sendFrontendMessage('navToEpicAndOpenGame', url)
+})

--- a/src/backend/storeManagers/hyperplay/library.ts
+++ b/src/backend/storeManagers/hyperplay/library.ts
@@ -9,7 +9,7 @@ import {
 } from 'common/types'
 import axios from 'axios'
 import { logInfo, LogPrefix, logError, logWarning } from 'backend/logger/logger'
-import { handleArchAndPlatform } from './utils'
+import { getGameInfoFromHpRelease, handleArchAndPlatform } from './utils'
 import { getGameInfo as getGamesGameInfo } from './games'
 
 export async function addGameToLibrary(appId: string) {
@@ -30,52 +30,7 @@ export async function addGameToLibrary(appId: string) {
   )
 
   const data = res.data[0]
-
-  const isWebGame = Object.hasOwn(data.releaseMeta.platforms, 'web')
-  const supportedPlatforms = Object.keys(data.releaseMeta.platforms)
-
-  const gameInfo: GameInfo = {
-    app_name: data._id,
-    extra: {
-      about: {
-        description: data.projectMeta.description,
-        shortDescription: data.projectMeta.short_description
-      },
-      reqs: [
-        {
-          minimum: JSON.stringify(data.projectMeta.systemRequirements),
-          recommended: JSON.stringify(data.projectMeta.systemRequirements),
-          title: data.projectMeta.name
-        }
-      ],
-      storeUrl: `https://store.hyperplay.xyz/game/${data.projectName}`
-    },
-    thirdPartyManagedApp: undefined,
-    web3: { supported: true },
-    runner: 'hyperplay',
-    title: data.projectMeta.name,
-    art_square: data.projectMeta.image || data.releaseMeta.image || 'fallback',
-    art_cover:
-      data.releaseMeta.image || data.projectMeta.main_capsule || 'fallback',
-    is_installed: Boolean(data.releaseMeta.platforms.web),
-    cloud_save_enabled: false,
-    namespace: '',
-    developer: data.accountMeta.name || data.accountName,
-    store_url: `https://store.hyperplay.xyz/game/${data.projectName}`,
-    folder_name: data.projectName,
-    save_folder: '',
-    is_mac_native: supportedPlatforms.some((val) => val.startsWith('darwin')),
-    is_linux_native: supportedPlatforms.some((val) => val.startsWith('linux')),
-    canRunOffline: false,
-    install: isWebGame ? { platform: 'web' } : {},
-    releaseMeta: data.releaseMeta,
-    version: data.releaseName
-  }
-
-  if (isWebGame) {
-    gameInfo.browserUrl = data.releaseMeta.platforms.web.external_url
-  }
-
+  const gameInfo = getGameInfoFromHpRelease(data)
   hpLibraryStore.set('games', [...currentLibrary, gameInfo])
 }
 

--- a/src/backend/storeManagers/hyperplay/utils.ts
+++ b/src/backend/storeManagers/hyperplay/utils.ts
@@ -1,10 +1,12 @@
 import {
   AppPlatforms,
+  GameInfo,
   HyperPlayRelease,
   HyperPlayReleaseMeta,
   InstallPlatform
 } from 'common/types'
 import axios from 'axios'
+import { getTitleFromEpicStoreUrl } from 'backend/utils'
 
 export async function getHyperPlayStoreRelease(appName: string) {
   const gameIdUrl = `https://developers.hyperplay.xyz/api/listings?id=${appName}`
@@ -88,3 +90,77 @@ export function handlePlatformReversed(platform: string) {
 
 export const macOSPlatforms = ['darwin', 'darwin_arm64', 'darwin_amd64']
 export const linuxPlatforms = ['linux', 'linux_arm64', 'linux_amd64']
+
+export function getGameInfoFromHpRelease(data: HyperPlayRelease): GameInfo {
+  const isWebGame = Object.hasOwn(data.releaseMeta.platforms, 'web')
+  const supportedPlatforms = Object.keys(data.releaseMeta.platforms)
+
+  const gameInfo: GameInfo = {
+    app_name: data._id,
+    extra: {
+      about: {
+        description: data.projectMeta.description,
+        shortDescription: data.projectMeta.short_description
+      },
+      reqs: [
+        {
+          minimum: JSON.stringify(data.projectMeta.systemRequirements),
+          recommended: JSON.stringify(data.projectMeta.systemRequirements),
+          title: data.projectMeta.name
+        }
+      ],
+      storeUrl: `https://store.hyperplay.xyz/game/${data.projectName}`
+    },
+    thirdPartyManagedApp: undefined,
+    web3: { supported: true },
+    runner: 'hyperplay',
+    title: data.projectMeta.name,
+    art_square: data.projectMeta.image || data.releaseMeta.image || 'fallback',
+    art_cover:
+      data.releaseMeta.image || data.projectMeta.main_capsule || 'fallback',
+    is_installed: Boolean(data.releaseMeta.platforms.web),
+    cloud_save_enabled: false,
+    namespace: '',
+    developer: data.accountMeta.name || data.accountName,
+    store_url: `https://store.hyperplay.xyz/game/${data.projectName}`,
+    folder_name: data.projectName,
+    save_folder: '',
+    is_mac_native: supportedPlatforms.some((val) => val.startsWith('darwin')),
+    is_linux_native: supportedPlatforms.some((val) => val.startsWith('linux')),
+    canRunOffline: false,
+    install: isWebGame ? { platform: 'web' } : {},
+    releaseMeta: data.releaseMeta,
+    version: data.releaseName
+  }
+
+  if (isWebGame) {
+    gameInfo.browserUrl = data.releaseMeta.platforms.web.external_url
+  }
+  return gameInfo
+}
+
+interface EpicToHpMap {
+  [key: string]: GameInfo
+}
+export const epicTitleToHpGameInfoMap: EpicToHpMap = {}
+
+export async function loadEpicHyperPlayGameInfoMap() {
+  const res = await axios.get<HyperPlayRelease[]>(
+    `https://developers.hyperplay.xyz/api/listings`
+  )
+
+  for (const hpRelease of res.data) {
+    if (!hpRelease.projectMeta.epic_game_url) continue
+    try {
+      const epicTitle = getTitleFromEpicStoreUrl(
+        hpRelease.projectMeta.epic_game_url
+      )
+
+      epicTitleToHpGameInfoMap[epicTitle.toLowerCase()] =
+        getGameInfoFromHpRelease(hpRelease)
+    } catch (err) {
+      console.error('Error while creating epic hp map', err)
+      continue
+    }
+  }
+}

--- a/src/backend/storeManagers/index.ts
+++ b/src/backend/storeManagers/index.ts
@@ -15,6 +15,7 @@ import { addToQueue } from 'backend/downloadmanager/downloadqueue'
 import { DMQueueElement, GameInfo } from 'common/types'
 import { ipcMain } from 'electron'
 import { sendFrontendMessage } from 'backend/main_window'
+import { loadEpicHyperPlayGameInfoMap } from './hyperplay/utils'
 interface GameManagerMap {
   [key: string]: GameManager
 }
@@ -81,6 +82,7 @@ export function autoUpdate(runner: string, gamesToUpdate: string[]) {
 export async function initStoreManagers() {
   await LegendaryLibraryManager.initLegendaryLibraryManager()
   await GOGLibraryManager.refresh()
+  loadEpicHyperPlayGameInfoMap()
 }
 
 ipcMain.once('frontendReady', async () => {

--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -618,7 +618,7 @@ async function loadAll(): Promise<string[]> {
   if (existsSync(legendaryMetadata)) {
     const loadedFiles: string[] = []
     for (const appName of allGames) {
-      const wasLoaded = await loadFile(appName + '.json')
+      const wasLoaded = loadFile(appName + '.json')
       if (wasLoaded) {
         loadedFiles.push(appName)
       }

--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -41,6 +41,7 @@ import { callRunner } from '../../launcher'
 import { dirname, join } from 'path'
 import { isOnline } from '../../online_monitor'
 import { update } from './games'
+import { epicTitleToHpGameInfoMap } from '../hyperplay/utils'
 
 const allGames: Set<string> = new Set()
 let installedGames: Map<string, InstalledJsonMetadata> = new Map()
@@ -534,11 +535,42 @@ function loadFile(fileName: string): boolean {
 
   const convertedSize = install_size ? getFileSize(Number(install_size)) : '0'
 
+  //check if game is also listed in hp
+  /* eslint-disable @typescript-eslint/no-unused-vars*/
+  const {
+    app_name: hp_app_name,
+    art_cover: hp_art_cover,
+    art_square: hp_art_square,
+    install: hp_install,
+    is_installed: hp_is_installed,
+    title: hp_title,
+    canRunOffline: hp_canRunOffline,
+    runner: hp_runner,
+    ...hpGameInfoToMerge
+  } = epicTitleToHpGameInfoMap[title.toLowerCase()]
+    ? epicTitleToHpGameInfoMap[title.toLowerCase()]
+    : {
+        app_name: '',
+        art_cover: '',
+        art_square: '',
+        install: {},
+        is_installed: false,
+        title: '',
+        canRunOffline: false,
+        runner: 'hyperplay'
+      }
+  /* eslint-enable @typescript-eslint/no-unused-vars*/
+
   library.set(app_name, {
     app_name,
-    art_cover: art_cover || art_square || fallBackImage,
+    art_cover: art_cover || art_square || hp_art_cover || fallBackImage,
     art_logo,
-    art_square: art_square || art_square_front || art_cover || fallBackImage,
+    art_square:
+      art_square ||
+      art_square_front ||
+      art_cover ||
+      hp_art_square ||
+      fallBackImage,
     cloud_save_enabled: Boolean(saveFolder),
     developer,
     extra: {
@@ -570,7 +602,8 @@ function loadFile(fileName: string): boolean {
     thirdPartyManagedApp,
     is_linux_native: false,
     runner: 'legendary',
-    store_url: formatEpicStoreUrl(title)
+    store_url: formatEpicStoreUrl(title),
+    ...hpGameInfoToMerge
   })
 
   return true
@@ -584,12 +617,12 @@ function loadFile(fileName: string): boolean {
 async function loadAll(): Promise<string[]> {
   if (existsSync(legendaryMetadata)) {
     const loadedFiles: string[] = []
-    allGames.forEach((appName) => {
-      const wasLoaded = loadFile(appName + '.json')
+    for (const appName of allGames) {
+      const wasLoaded = await loadFile(appName + '.json')
       if (wasLoaded) {
         loadedFiles.push(appName)
       }
-    })
+    }
     return loadedFiles
   }
   return []

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -623,6 +623,11 @@ const formatEpicStoreUrl = (title: string) => {
   return `${storeUrl}${cleanTitle(title)}`
 }
 
+const getTitleFromEpicStoreUrl = (url: string) => {
+  const urlTest = new URL(url)
+  return urlTest.pathname.split('/')[3]
+}
+
 function quoteIfNecessary(stringToQuote: string) {
   const shouldQuote =
     typeof stringToQuote === 'string' &&
@@ -1307,7 +1312,8 @@ export {
   getFileSize,
   getLegendaryVersion,
   getGogdlVersion,
-  shutdownWine
+  shutdownWine,
+  getTitleFromEpicStoreUrl
 }
 
 // Exported only for testing purpose

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -116,6 +116,7 @@ interface SyncIPCFunctions extends HyperPlaySyncIPCFunctions {
   changeTrayColor: () => void
   setSetting: (args: { appName: string; key: string; value: unknown }) => void
   optInStatusChanged: (optInStatus: MetricsOptInStatus) => void
+  openGameInEpicStore: (url: string) => void
 }
 
 interface RequestArguments {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -767,6 +767,8 @@ interface HyperPlayProjectMeta {
   systemRequirements: SystemRequirements
   wineSupport: WineSupport
   networks: string[]
+  launch_epic?: boolean
+  epic_game_url?: string
 }
 
 export type AppPlatforms =

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -27,6 +27,7 @@ import { observer } from 'mobx-react-lite'
 import TransactionNotification from './screens/TransactionNotification'
 import ExternalLinkDialog from './components/UI/ExternalLinkDialog'
 import SettingsModal from './screens/Settings/components/SettingsModal'
+import StoreNavHandler from './StoreNavHandler'
 
 function App() {
   const { sidebarCollapsed, isSettingsModalOpen } = useContext(ContextProvider)
@@ -41,6 +42,7 @@ function App() {
           <ExtensionManager />
           <DialogHandler />
           <ExternalLinkDialog />
+          <StoreNavHandler />
           {isSettingsModalOpen.gameInfo && (
             <SettingsModal
               gameInfo={isSettingsModalOpen.gameInfo}

--- a/src/frontend/StoreNavHandler/index.tsx
+++ b/src/frontend/StoreNavHandler/index.tsx
@@ -4,7 +4,8 @@ import { useNavigate } from 'react-router-dom'
 export default function StoreNavHandler() {
   const navigate = useNavigate()
   function handleNavToEpic(_e: Electron.IpcRendererEvent, url: string) {
-    navigate(`/store-page/?store-url=${url}`)
+    if (url.startsWith('https://store.epicgames.com/'))
+      navigate(`/store-page/?store-url=${url}`)
   }
   useEffect(() => {
     const rmHandleNavToEpic = window.api.handleNavToEpicAndOpen(handleNavToEpic)

--- a/src/frontend/StoreNavHandler/index.tsx
+++ b/src/frontend/StoreNavHandler/index.tsx
@@ -1,0 +1,16 @@
+import React, { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+export default function StoreNavHandler() {
+  const navigate = useNavigate()
+  function handleNavToEpic(_e: Electron.IpcRendererEvent, url: string) {
+    navigate(`/store-page/?store-url=${url}`)
+  }
+  useEffect(() => {
+    const rmHandleNavToEpic = window.api.handleNavToEpicAndOpen(handleNavToEpic)
+    return () => {
+      rmHandleNavToEpic()
+    }
+  })
+  return <></>
+}


### PR DESCRIPTION
For games with 
```
launch_epic?: boolean
epic_game_url?: string
```
defined, this [store PR](https://github.com/HyperPlay-Gaming/hyperplay-store/pull/11) will show the game page action button as "Play in Epic Store" and after clicking it, the user will be navigated to the corresponding listing in the Epic Store.

When the game is added and getGameInfo is called for the epic game, a map (generated on client start) will merge the HyperPlay listing `GameInfo` metadata with the legendary metadata. This way we can still show web3/HyperPlay specific metadata like token requirements even though the game is managed by legendary

To test, you will need to 
1. replace the developers.hyperplay.api/listings axios calls with a test.json that you import.
2. manually change one of the game's metadata to have `launch_epic: true` and `epic_game_url: https://store.epicgames.com/en-US/p/fall-guys` or some other epic game that you have added to your library
3. run [this store PR branch](https://github.com/HyperPlay-Gaming/hyperplay-store/pull/11)
4. set the store url in hp client to http://localhost:3000
5. navigate to the hp store in the client
6. navigate to the game you modified in the hp store
7. Click "Play in Epic Store"
8. See that it navigates you to the epic store. once you do that make sure the game is added to your legendary/epic library and go to the library screen
9. Click on the epic games listing and you should see some of the fields from the hp listing like "has web3 features: true"

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
