### PR TITLE
[Fix] Hotfix

### DIFF
--- a/src/backend/downloadmanager/utils.ts
+++ b/src/backend/downloadmanager/utils.ts
@@ -54,10 +54,12 @@ async function installQueueElement(params: InstallParams): Promise<{
     }
   })
 
+  const startingStatus = runner === 'hyperplay' ? 'preparing' : 'installing'
+
   sendFrontendMessage('gameStatusUpdate', {
     appName,
     runner,
-    status: 'installing',
+    status: startingStatus,
     folder: path
   })
 

--- a/src/backend/storeManagers/hyperplay/games.ts
+++ b/src/backend/storeManagers/hyperplay/games.ts
@@ -197,6 +197,7 @@ async function downloadGame(
   destinationPath: string
 ): Promise<void> {
   const appInfo = getGameInfo(appName)
+  let downloadStarted = false
 
   if (!appInfo || !appInfo.releaseMeta) {
     throw new Error('App not found in library')
@@ -226,6 +227,16 @@ async function downloadGame(
           downloadSpeed,
           platformInfo.downloadSize
         )
+
+        if (downloadedBytes > 0 && !downloadStarted) {
+          downloadStarted = true
+          sendFrontendMessage('gameStatusUpdate', {
+            appName,
+            status: 'installing',
+            runner: 'hyperplay',
+            folder: destinationPath
+          })
+        }
 
         window.webContents.send(`progressUpdate-${appName}`, {
           appName,

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -1235,7 +1235,6 @@ export async function downloadFile(
       existBehavior: 'overwrite',
       maxRetry: 10,
       retryDelay: 1000,
-      connections: 1,
       chunkSize: 1024 * 1024 * 10
     }).start()
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -191,6 +191,7 @@ export type Status =
   | 'installed'
   | 'extracting'
   | 'paused'
+  | 'preparing'
 
 export interface GameStatus {
   appName: string

--- a/src/frontend/hooks/constants.ts
+++ b/src/frontend/hooks/constants.ts
@@ -34,7 +34,8 @@ export function getStatusLabel({
       runner === 'sideload' ? '' : size
     }`,
     notInstalled: t('gamepage:status.notinstalled'),
-    paused: t('gamepage:status.paused', 'Paused')
+    paused: t('gamepage:status.paused', 'Paused'),
+    preparing: t('gamepage:status.preparing', 'Preparing')
   }
 
   return statusMap[status] || t('gamepage:status.notinstalled')

--- a/src/frontend/screens/Accessibility/index.css
+++ b/src/frontend/screens/Accessibility/index.css
@@ -50,3 +50,9 @@ input[type='range'] {
 .Accessibility h1.headerTitle {
   margin-left: 0px;
 }
+
+.rangeWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -118,6 +118,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
   const isSyncing = status === 'syncing-saves'
   const isPaused = status === 'paused'
   const isExtracting = status === 'extracting'
+  const isPreparing = status === 'preparing'
   const notAvailable = !gameAvailable && gameInfo.is_installed
   const notSupportedGame =
     gameInfo.runner !== 'sideload' && gameInfo.thirdPartyManagedApp === 'Origin'
@@ -650,6 +651,10 @@ export default React.memo(function GamePage(): JSX.Element | null {
       return t('status.paused', 'Paused')
     }
 
+    if (isPreparing) {
+      return t('status.preparing', 'Preparing Download, please wait')
+    }
+
     if (notSupportedGame) {
       return t(
         'status.this-game-uses-third-party',
@@ -764,7 +769,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
     if (isExtracting) {
       return t('status.extracting', 'Extracting files')
     }
-    if (isInstalling) {
+    if (isInstalling || isPreparing) {
       return t('button.queue.cancel', 'Cancel Download')
     }
     return t('button.install')

--- a/src/frontend/screens/Library/components/GameCard/constants.ts
+++ b/src/frontend/screens/Library/components/GameCard/constants.ts
@@ -31,6 +31,7 @@ export function getCardStatus(
   const notSupportedGame = status === 'notSupportedGame'
   const syncingSaves = status === 'syncing-saves'
   const isPaused = status === 'paused'
+  const isPreparing = status === 'preparing'
 
   const haveStatus =
     isMoving ||
@@ -44,7 +45,9 @@ export function getCardStatus(
     isPlaying ||
     syncingSaves ||
     (isInstalled && layout !== 'grid') ||
-    isPaused
+    isPaused ||
+    isPreparing
+
   return {
     isInstalling,
     notSupportedGame,
@@ -54,6 +57,7 @@ export function getCardStatus(
     notAvailable,
     isUpdating,
     isPaused,
+    isPreparing,
     haveStatus
   }
 }

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -581,7 +581,11 @@ class GlobalState extends PureComponent<Props> {
     )
 
     // in these cases we just add the new status
-    if (['installing', 'updating', 'playing', 'extracting'].includes(status)) {
+    if (
+      ['installing', 'updating', 'playing', 'extracting', 'preparing'].includes(
+        status
+      )
+    ) {
       currentApp.status = status
       newLibraryStatus.push(currentApp)
       this.setState({ libraryStatus: newLibraryStatus })


### PR DESCRIPTION
EasyDL downloads chunks in parallel so connections cannot equal 1 without losing the pause feature and forcing the download into a single chunk 

also includes a small css fix to settings

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
