### PR TITLE
[Fix] Handle Invalid Download Urls

### DIFF
--- a/src/backend/storeManagers/hyperplay/library.ts
+++ b/src/backend/storeManagers/hyperplay/library.ts
@@ -22,6 +22,9 @@ export async function addGameToLibrary(appId: string) {
   })
 
   if (sameGameInLibrary !== undefined) {
+    logWarning(
+      `Cannot add game to library since game is already added to the library!`
+    )
     return
   }
 

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -1244,7 +1244,7 @@ export async function downloadFile(
 
   let connections = 1
   try {
-    const response = await axios.head(url)
+    const response = await axios.head(encodeURI(url))
     const cdnCache = response.headers['cdn-cache']
     const isCached = cdnCache === 'HIT' || cdnCache === 'STALE'
     if (isCached) {
@@ -1253,7 +1253,7 @@ export async function downloadFile(
     fileSize = parseInt(response.headers['content-length'], 10)
   } catch (err) {
     logError(
-      `Downloader: Failed to get headers for ${url}`,
+      `Downloader: Failed to get headers for ${url}. \nError: ${err}`,
       LogPrefix.DownloadManager
     )
     throw new Error('Failed to get headers')


### PR DESCRIPTION
This fixes an issue with `the wake prealpha` failing to download

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
