### PR TITLE
[Feature] Add copy base uri button

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -48,10 +48,10 @@
         "yesCancel": "Yes, cancel"
     },
     "button": {
-        "add_to_favourites": "Add To Favourites",
         "cancel": "Pause/Cancel",
         "continue": "Continue Download",
         "details": "Details",
+        "favorites": "Favorite",
         "finish": "Finish",
         "force_update": "Force Update if Available",
         "force-innstall": "Force Install",
@@ -60,15 +60,17 @@
         "install": "Install",
         "no-path-selected": "No path selected",
         "queue": {
+            "cancel": "Cancel Download",
+            "continue": "Continue Download",
             "remove": "Remove from Queue"
         },
-        "remove_from_favourites": "Remove From Favourites",
         "remove_from_recent": "Remove From Recent",
         "run-exe-first": "Run Installer First",
         "running-setup": "Running Setup",
         "sideload": {
             "edit": "Edit App/Game"
         },
+        "unfavorites": "Unfavorite",
         "unhide_game": "Unhide Game",
         "uninstall": "Uninstall",
         "update": "Update"
@@ -107,6 +109,13 @@
         "main-story": "Main Story"
     },
     "howLongToBeat": "How Long To Beat",
+    "hyperplay": {
+        "gamecard": {
+            "extracting": "Extracting...",
+            "installing": "Downloading...",
+            "paused": "Paused"
+        }
+    },
     "info": {
         "canRunOffline": "Online Required",
         "installedPlatform": "Installed Platform",
@@ -126,9 +135,6 @@
         "wineversion": "Wine version"
     },
     "label": {
-        "game": {
-            "third-party-game": "Third-Party Game NOT Supported"
-        },
         "playing": {
             "start": "Play",
             "stop": "Playing (Stop)"
@@ -188,7 +194,9 @@
         "notinstalled": "This game is not installed",
         "notSupported": "Not supported",
         "notSupportedGame": "Not Supported",
+        "paused": "Paused",
         "playing": "Playing",
+        "preparing": "Preparing Download, please wait",
         "processing": "Processing files, please wait",
         "queued": "Queued",
         "reparing": "Repairing Game, please wait",

--- a/public/locales/en/login.json
+++ b/public/locales/en/login.json
@@ -1,5 +1,7 @@
 {
     "button": {
+        "error": "Error, try a different Code",
+        "loading": "Loading",
         "login": "Log in"
     },
     "message": {
@@ -11,10 +13,6 @@
         "part6": "Paste your",
         "part7": "authorization code number",
         "part8": "in the input box below and click on the login button."
-    },
-    "status": {
-        "error": "Error",
-        "loading": "Loading Game list, please wait"
     },
     "welcome": "Welcome!"
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -271,6 +271,7 @@
             "noThanks": "No Thanks"
         },
         "changeWallet": "Change wallet",
+        "copyBaseUri": "Copy Base URI",
         "currentWallet": "Current wallet",
         "discordApp": "Discord",
         "misc": "Never",
@@ -303,7 +304,8 @@
                     "import": {
                         "createNewWallet": "Create new MM extension wallet",
                         "details": "By importing, your MetaMask installation and  settings will be imported into HyperPlay.",
-                        "title": "Select the browser to import from"
+                        "title": "Select the browser to import from",
+                        "useRecoveryPhrase": "Access with secret recovery phrase"
                     },
                     "info": {
                         "createWalletCTA": "Create a wallet",
@@ -391,9 +393,6 @@
     },
     "info": {
         "hyperplay": {
-            "beta": "Beta",
-            "newReleases": "Update Available!",
-            "stable": "Stable",
             "version": "HyperPlay Version"
         },
         "save-sync": {
@@ -765,7 +764,6 @@
     "wine": {
         "actions": "Action",
         "manager": {
-            "link": "Compatibility Layer ",
             "not-found": "No Wine versions found. Please click the refresh icon to try again.",
             "title": "Compatibility Layer ",
             "unzipping": "Unzipping"

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -271,7 +271,7 @@
             "noThanks": "No Thanks"
         },
         "changeWallet": "Change wallet",
-        "copyBaseUri": "Copy Base URI",
+        "copyUrl": "Copy URL",
         "currentWallet": "Current wallet",
         "discordApp": "Discord",
         "misc": "Never",

--- a/src/backend/api/misc.ts
+++ b/src/backend/api/misc.ts
@@ -154,3 +154,7 @@ export const handleNavToEpicAndOpen = (
     ipcRenderer.removeListener('navToEpicAndOpenGame', onMessage)
   }
 }
+
+export const copyWalletConnectBaseURIToClipboard = () => {
+  ipcRenderer.send('copyWalletConnectBaseURIToClipboard')
+}

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -44,7 +44,6 @@ import {
 import { promisify } from 'util'
 import i18next, { t } from 'i18next'
 import si from 'systeminformation'
-import unzipper from 'unzipper'
 
 import {
   fixAsarPath,
@@ -86,7 +85,6 @@ import {
   updateWineVersionInfos,
   wineDownloaderInfoStore
 } from './wine/manager/utils'
-import { clean } from 'easydl/dist/utils'
 
 const execAsync = promisify(exec)
 

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -120,6 +120,7 @@ interface SyncIPCFunctions extends HyperPlaySyncIPCFunctions {
   resumeCurrentDownload: () => void
   pauseCurrentDownload: () => void
   cancelDownload: (removeDownloaded: boolean) => void
+  copyWalletConnectBaseURIToClipboard: () => void
 }
 
 interface RequestArguments {

--- a/src/frontend/screens/Onboarding/walletSelection/index.module.scss
+++ b/src/frontend/screens/Onboarding/walletSelection/index.module.scss
@@ -37,7 +37,7 @@
 }
 
 .walletOptionsContainer {
-  margin-top: auto;
+  margin-bottom: auto;
 }
 
 .walletOptionsContainer > button:last-child {

--- a/src/frontend/screens/Onboarding/walletSelection/screens/scan/index.tsx
+++ b/src/frontend/screens/Onboarding/walletSelection/screens/scan/index.tsx
@@ -54,7 +54,7 @@ const ScanScreen = (props: ScanScreenProps) => {
           style={{ width: '200px', margin: '0px auto var(--space-xs) auto' }}
           onClick={() => window.api.copyWalletConnectBaseURIToClipboard()}
         >
-          {t('hyperplay.copyBaseUri', 'Copy Base URI')}
+          {t('hyperplay.copyUrl', 'Copy URL')}
         </Button>
       ) : null}
       <div className={`body-sm ${ScanScreenStyles.walletWarning}`}>

--- a/src/frontend/screens/Onboarding/walletSelection/screens/scan/index.tsx
+++ b/src/frontend/screens/Onboarding/walletSelection/screens/scan/index.tsx
@@ -47,14 +47,16 @@ const ScanScreen = (props: ScanScreenProps) => {
           )}
         </a>
       </div>
-      <Button
-        size="small"
-        type="secondary"
-        style={{ width: '200px', margin: '0px auto var(--space-xs) auto' }}
-        onClick={() => window.api.copyWalletConnectBaseURIToClipboard()}
-      >
-        Copy Base URI
-      </Button>
+      {!props.providerName.toLowerCase().includes('metamask') ? (
+        <Button
+          size="small"
+          type="secondary"
+          style={{ width: '200px', margin: '0px auto var(--space-xs) auto' }}
+          onClick={() => window.api.copyWalletConnectBaseURIToClipboard()}
+        >
+          {t('hyperplay.copyBaseUri', 'Copy Base URI')}
+        </Button>
+      ) : null}
       <div className={`body-sm ${ScanScreenStyles.walletWarning}`}>
         <WarningIcon height={15} fill={'var(--color-status-alert)'} />
         <div>

--- a/src/frontend/screens/Onboarding/walletSelection/screens/scan/index.tsx
+++ b/src/frontend/screens/Onboarding/walletSelection/screens/scan/index.tsx
@@ -3,6 +3,7 @@ import { t } from 'i18next'
 import QrCodeGradientBorder from '../../../components/qrCodeGradientBorder'
 import ScanScreenStyles from './index.module.scss'
 import { WarningIcon } from 'frontend/assets/hyperplay'
+import { Button } from '@hyperplay/ui'
 
 interface ScanScreenProps {
   qrCodeSvg: string
@@ -46,6 +47,14 @@ const ScanScreen = (props: ScanScreenProps) => {
           )}
         </a>
       </div>
+      <Button
+        size="small"
+        type="secondary"
+        style={{ width: '200px', margin: '0px auto var(--space-xs) auto' }}
+        onClick={() => window.api.copyWalletConnectBaseURIToClipboard()}
+      >
+        Copy Base URI
+      </Button>
       <div className={`body-sm ${ScanScreenStyles.walletWarning}`}>
         <WarningIcon height={15} fill={'var(--color-status-alert)'} />
         <div>


### PR DESCRIPTION
This allows the user to use wallet connect with wallets that cannot parse out the base uri from the metamask deep link qr code

To test Ledger Live for example
1. Go to accounts
2. click on an account
3. click wallet connect icon in top right
4. paste URL you copied with the copy base uri button

#### Screenshots
wallet connect has base uri button
<img width="986" alt="image" src="https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/assets/27568879/77a5bdb9-cc75-433d-bf36-56ce821cb590">

mm mobile does not have the base uri button
<img width="876" alt="image" src="https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/assets/27568879/4eb749ae-1cdd-4fd3-9cf3-a8f1d0b9f749">


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
