### PR TITLE
[Metrics] Add game launch and closed events, add game_title

### DIFF
--- a/src/backend/downloadmanager/utils.ts
+++ b/src/backend/downloadmanager/utils.ts
@@ -51,7 +51,8 @@ async function installQueueElement(params: InstallParams): Promise<{
     properties: {
       game_name: appName,
       store_name: runner,
-      game_title: title
+      game_title: title,
+      platform: platformToInstall
     }
   })
 
@@ -98,7 +99,8 @@ async function installQueueElement(params: InstallParams): Promise<{
       properties: {
         game_name: appName,
         store_name: runner,
-        game_title: title
+        game_title: title,
+        platform: platformToInstall
       }
     })
 
@@ -117,7 +119,8 @@ async function installQueueElement(params: InstallParams): Promise<{
         game_name: appName,
         store_name: runner,
         error: `${error}`,
-        game_title: title
+        game_title: title,
+        platform: platformToInstall
       }
     })
     errorMessage(`${error}`)
@@ -178,7 +181,8 @@ async function updateQueueElement(params: InstallParams): Promise<{
     properties: {
       game_name: appName,
       store_name: runner,
-      game_title: title
+      game_title: title,
+      platform: params.platformToInstall
     }
   })
   const errorMessage = (error: string) => {
@@ -199,7 +203,8 @@ async function updateQueueElement(params: InstallParams): Promise<{
         properties: {
           game_name: appName,
           store_name: runner,
-          game_title: title
+          game_title: title,
+          platform: params.platformToInstall
         }
       })
     }
@@ -213,7 +218,8 @@ async function updateQueueElement(params: InstallParams): Promise<{
         game_name: appName,
         store_name: runner,
         error: 'update aborted',
-        game_title: title
+        game_title: title,
+        platform: params.platformToInstall
       }
     })
     notify({ title, body: i18next.t('notify.update.canceled') })

--- a/src/backend/downloadmanager/utils.ts
+++ b/src/backend/downloadmanager/utils.ts
@@ -50,7 +50,8 @@ async function installQueueElement(params: InstallParams): Promise<{
     event: 'Game Install Started',
     properties: {
       game_name: appName,
-      store_name: runner
+      store_name: runner,
+      game_title: title
     }
   })
 
@@ -96,7 +97,8 @@ async function installQueueElement(params: InstallParams): Promise<{
       event: 'Game Install Success',
       properties: {
         game_name: appName,
-        store_name: runner
+        store_name: runner,
+        game_title: title
       }
     })
 
@@ -114,7 +116,8 @@ async function installQueueElement(params: InstallParams): Promise<{
       properties: {
         game_name: appName,
         store_name: runner,
-        error: `${error}`
+        error: `${error}`,
+        game_title: title
       }
     })
     errorMessage(`${error}`)
@@ -174,7 +177,8 @@ async function updateQueueElement(params: InstallParams): Promise<{
     event: 'Game Update Started',
     properties: {
       game_name: appName,
-      store_name: runner
+      store_name: runner,
+      game_title: title
     }
   })
   const errorMessage = (error: string) => {
@@ -194,7 +198,8 @@ async function updateQueueElement(params: InstallParams): Promise<{
         event: 'Game Update Success',
         properties: {
           game_name: appName,
-          store_name: runner
+          store_name: runner,
+          game_title: title
         }
       })
     }
@@ -207,7 +212,8 @@ async function updateQueueElement(params: InstallParams): Promise<{
       properties: {
         game_name: appName,
         store_name: runner,
-        error: 'update aborted'
+        error: 'update aborted',
+        game_title: title
       }
     })
     notify({ title, body: i18next.t('notify.update.canceled') })

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1222,12 +1222,12 @@ ipcMain.handle(
       status: 'uninstalling'
     })
 
+    const { title } = gameManagerMap[runner].getGameInfo(appName)
+
     trackEvent({
       event: 'Game Uninstall Started',
-      properties: { game_name: appName, store_name: runner }
+      properties: { game_name: appName, store_name: runner, game_title: title }
     })
-
-    const { title } = gameManagerMap[runner].getGameInfo(appName)
 
     let uninstalled = false
 
@@ -1240,7 +1240,8 @@ ipcMain.handle(
         properties: {
           game_name: appName,
           store_name: runner,
-          error: `${error}`
+          error: `${error}`,
+          game_title: title
         }
       })
       notify({
@@ -1275,7 +1276,11 @@ ipcMain.handle(
 
       trackEvent({
         event: 'Game Uninstall Success',
-        properties: { game_name: appName, store_name: runner }
+        properties: {
+          game_name: appName,
+          store_name: runner,
+          game_title: title
+        }
       })
 
       notify({ title, body: i18next.t('notify.uninstalled') })

--- a/src/backend/metrics/metrics.ts
+++ b/src/backend/metrics/metrics.ts
@@ -1,11 +1,13 @@
 import { apiObject } from '@rudderstack/rudder-sdk-node'
 import { sendFrontendMessage } from 'backend/main_window'
-import { MetricsOptInStatus } from 'common/types'
+import { GameInfo, MetricsOptInStatus } from 'common/types'
 import Store from 'electron-store'
 import web3 from 'web3'
-import { getAppVersion, getFormattedOsName } from '../utils'
+import { getAppVersion, getFormattedOsName, processIsClosed } from '../utils'
 import { rudderstack } from './rudderstack-client'
 import { PossibleMetricEventNames, PossibleMetricPayloads } from './types'
+import { hrtime } from 'process'
+import find from 'find-process'
 
 /**
  * Our global anonymous id which is used for any events that contain data that
@@ -204,5 +206,53 @@ export const changeMetricsOptInStatus = async (
     trackEvent({
       event: 'Metrics Opt-out'
     })
+  }
+}
+
+export async function trackPidPlaytime(
+  pid: string | number,
+  gameInfo: GameInfo
+) {
+  try {
+    const start = hrtime.bigint()
+    const processInfoArr = await find('pid', pid)
+    if (processInfoArr.length === 0) {
+      console.log('No process info found with pid', pid)
+      return
+    }
+    for (const processInfo of processInfoArr) {
+      trackEvent({
+        event: 'Game Launched',
+        properties: {
+          isBrowserGame: false,
+          game_name: gameInfo.app_name,
+          game_title: gameInfo.title,
+          store_name: gameInfo.runner,
+          processName: processInfo.name
+        }
+      })
+    }
+
+    // wait for process to close
+    const pidNum = typeof pid === 'number' ? pid : Number.parseInt(pid)
+    await processIsClosed(pidNum)
+
+    const end = hrtime.bigint()
+    const elapsedInMs = Math.round(Number(end - start) / 10 ** 6)
+    for (const processInfo of processInfoArr) {
+      trackEvent({
+        event: 'Game Closed',
+        properties: {
+          isBrowserGame: false,
+          game_name: gameInfo.app_name,
+          game_title: gameInfo.title,
+          store_name: gameInfo.runner,
+          processName: processInfo.name,
+          playTimeInMs: elapsedInMs
+        }
+      })
+    }
+  } catch (err) {
+    console.error(err)
   }
 }

--- a/src/backend/metrics/types.ts
+++ b/src/backend/metrics/types.ts
@@ -1,3 +1,5 @@
+import { AppPlatforms, InstallPlatform } from 'common/types'
+
 export interface MetricsOptIn {
   event: 'Metrics Opt-in'
   properties?: never
@@ -42,6 +44,7 @@ export interface GameInstallRequested {
     store_name: string
     game_name: string
     game_title: string
+    platform: InstallPlatform | AppPlatforms
   }
   sensitiveProperties?: never
 }
@@ -52,6 +55,7 @@ export interface GameInstallStarted {
     store_name: string
     game_name: string
     game_title: string
+    platform: InstallPlatform | AppPlatforms
   }
   sensitiveProperties?: never
 }
@@ -62,6 +66,7 @@ export interface GameInstallSuccess {
     store_name: string
     game_name: string
     game_title: string
+    platform: InstallPlatform | AppPlatforms
   }
   sensitiveProperties?: never
 }
@@ -73,6 +78,7 @@ export interface GameInstallFailed {
     game_name: string
     error: string
     game_title: string
+    platform: InstallPlatform | AppPlatforms
   }
   sensitiveProperties?: never
 }
@@ -83,6 +89,7 @@ export interface GameUpdateRequested {
     store_name: string
     game_name: string
     game_title: string
+    platform: InstallPlatform | AppPlatforms
   }
   sensitiveProperties?: never
 }
@@ -93,6 +100,7 @@ export interface GameUpdateStarted {
     store_name: string
     game_name: string
     game_title: string
+    platform: InstallPlatform | AppPlatforms
   }
   sensitiveProperties?: never
 }
@@ -103,6 +111,7 @@ export interface GameUpdateSuccess {
     store_name: string
     game_name: string
     game_title: string
+    platform: InstallPlatform | AppPlatforms
   }
   sensitiveProperties?: never
 }
@@ -114,6 +123,7 @@ export interface GameUpdateFailed {
     game_name: string
     error: string
     game_title: string
+    platform: InstallPlatform | AppPlatforms
   }
   sensitiveProperties?: never
 }

--- a/src/backend/metrics/types.ts
+++ b/src/backend/metrics/types.ts
@@ -41,6 +41,7 @@ export interface GameInstallRequested {
   properties: {
     store_name: string
     game_name: string
+    game_title: string
   }
   sensitiveProperties?: never
 }
@@ -50,6 +51,7 @@ export interface GameInstallStarted {
   properties: {
     store_name: string
     game_name: string
+    game_title: string
   }
   sensitiveProperties?: never
 }
@@ -59,6 +61,7 @@ export interface GameInstallSuccess {
   properties: {
     store_name: string
     game_name: string
+    game_title: string
   }
   sensitiveProperties?: never
 }
@@ -69,6 +72,7 @@ export interface GameInstallFailed {
     store_name: string
     game_name: string
     error: string
+    game_title: string
   }
   sensitiveProperties?: never
 }
@@ -78,6 +82,7 @@ export interface GameUpdateRequested {
   properties: {
     store_name: string
     game_name: string
+    game_title: string
   }
   sensitiveProperties?: never
 }
@@ -87,6 +92,7 @@ export interface GameUpdateStarted {
   properties: {
     store_name: string
     game_name: string
+    game_title: string
   }
   sensitiveProperties?: never
 }
@@ -96,6 +102,7 @@ export interface GameUpdateSuccess {
   properties: {
     store_name: string
     game_name: string
+    game_title: string
   }
   sensitiveProperties?: never
 }
@@ -106,6 +113,7 @@ export interface GameUpdateFailed {
     store_name: string
     game_name: string
     error: string
+    game_title: string
   }
   sensitiveProperties?: never
 }
@@ -115,6 +123,7 @@ export interface GameUninstallRequested {
   properties: {
     store_name: string
     game_name: string
+    game_title: string
   }
   sensitiveProperties?: never
 }
@@ -124,6 +133,7 @@ export interface GameUninstallStarted {
   properties: {
     store_name: string
     game_name: string
+    game_title: string
   }
   sensitiveProperties?: never
 }
@@ -133,6 +143,7 @@ export interface GameUninstallSuccess {
   properties: {
     store_name: string
     game_name: string
+    game_title: string
   }
   sensitiveProperties?: never
 }
@@ -143,6 +154,7 @@ export interface GameUninstallFailed {
     store_name: string
     game_name: string
     error: string
+    game_title: string
   }
   sensitiveProperties?: never
 }

--- a/src/backend/metrics/types.ts
+++ b/src/backend/metrics/types.ts
@@ -1,4 +1,4 @@
-import { AppPlatforms, InstallPlatform } from 'common/types'
+import { AppPlatforms, InstallPlatform, Runner } from 'common/types'
 
 export interface MetricsOptIn {
   event: 'Metrics Opt-in'
@@ -15,7 +15,7 @@ export interface MetricsOptOut {
 export interface GameStoreConnectionStarted {
   event: 'Game Store Connection Started'
   properties?: {
-    store_name: string
+    store_name: Runner
   }
   sensitiveProperties?: never
 }
@@ -41,7 +41,7 @@ export interface OnboardingCompleted {
 export interface GameInstallRequested {
   event: 'Game Install Requested'
   properties: {
-    store_name: string
+    store_name: Runner
     game_name: string
     game_title: string
     platform: InstallPlatform | AppPlatforms
@@ -52,7 +52,7 @@ export interface GameInstallRequested {
 export interface GameInstallStarted {
   event: 'Game Install Started'
   properties: {
-    store_name: string
+    store_name: Runner
     game_name: string
     game_title: string
     platform: InstallPlatform | AppPlatforms
@@ -63,7 +63,7 @@ export interface GameInstallStarted {
 export interface GameInstallSuccess {
   event: 'Game Install Success'
   properties: {
-    store_name: string
+    store_name: Runner
     game_name: string
     game_title: string
     platform: InstallPlatform | AppPlatforms
@@ -74,7 +74,7 @@ export interface GameInstallSuccess {
 export interface GameInstallFailed {
   event: 'Game Install Failed'
   properties: {
-    store_name: string
+    store_name: Runner
     game_name: string
     error: string
     game_title: string
@@ -86,7 +86,7 @@ export interface GameInstallFailed {
 export interface GameUpdateRequested {
   event: 'Game Update Requested'
   properties: {
-    store_name: string
+    store_name: Runner
     game_name: string
     game_title: string
     platform: InstallPlatform | AppPlatforms
@@ -97,7 +97,7 @@ export interface GameUpdateRequested {
 export interface GameUpdateStarted {
   event: 'Game Update Started'
   properties: {
-    store_name: string
+    store_name: Runner
     game_name: string
     game_title: string
     platform: InstallPlatform | AppPlatforms
@@ -108,7 +108,7 @@ export interface GameUpdateStarted {
 export interface GameUpdateSuccess {
   event: 'Game Update Success'
   properties: {
-    store_name: string
+    store_name: Runner
     game_name: string
     game_title: string
     platform: InstallPlatform | AppPlatforms
@@ -119,7 +119,7 @@ export interface GameUpdateSuccess {
 export interface GameUpdateFailed {
   event: 'Game Update Failed'
   properties: {
-    store_name: string
+    store_name: Runner
     game_name: string
     error: string
     game_title: string
@@ -131,7 +131,7 @@ export interface GameUpdateFailed {
 export interface GameUninstallRequested {
   event: 'Game Uninstall Requested'
   properties: {
-    store_name: string
+    store_name: Runner
     game_name: string
     game_title: string
   }
@@ -141,7 +141,7 @@ export interface GameUninstallRequested {
 export interface GameUninstallStarted {
   event: 'Game Uninstall Started'
   properties: {
-    store_name: string
+    store_name: Runner
     game_name: string
     game_title: string
   }
@@ -151,7 +151,7 @@ export interface GameUninstallStarted {
 export interface GameUninstallSuccess {
   event: 'Game Uninstall Success'
   properties: {
-    store_name: string
+    store_name: Runner
     game_name: string
     game_title: string
   }
@@ -161,7 +161,7 @@ export interface GameUninstallSuccess {
 export interface GameUninstallFailed {
   event: 'Game Uninstall Failed'
   properties: {
-    store_name: string
+    store_name: Runner
     game_name: string
     error: string
     game_title: string
@@ -173,6 +173,33 @@ export interface DownloadToastInteraction {
   event: 'DownloadToastInteraction'
   properties: {
     buttonClicked: string
+  }
+  sensitiveProperties?: never
+}
+
+export interface GameLaunch {
+  event: 'Game Launched'
+  properties: {
+    isBrowserGame: boolean
+    game_name: string
+    store_name: Runner
+    game_title: string
+    browserUrl?: string
+    processName?: string
+  }
+  sensitiveProperties?: never
+}
+
+export interface GameClosed {
+  event: 'Game Closed'
+  properties: {
+    isBrowserGame: boolean
+    game_name: string
+    store_name: Runner
+    game_title: string
+    playTimeInMs: number
+    browserUrl?: string
+    processName?: string
   }
   sensitiveProperties?: never
 }
@@ -197,5 +224,7 @@ export type PossibleMetricPayloads =
   | GameUninstallSuccess
   | GameUninstallFailed
   | DownloadToastInteraction
+  | GameLaunch
+  | GameClosed
 
 export type PossibleMetricEventNames = PossibleMetricPayloads['event']

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -516,7 +516,9 @@ export async function launch(
       onOutput: (output: string) => {
         appendFileSync(logFileLocation(appName), output)
       }
-    }
+    },
+    gameInfo,
+    true
   )
 
   deleteAbortController(appName)

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -984,7 +984,9 @@ export async function getLinuxInstallerInfo(appName: string): Promise<
 export async function runRunnerCommand(
   commandParts: string[],
   abortController: AbortController,
-  options?: CallRunnerOptions
+  options?: CallRunnerOptions,
+  gameInfo?: GameInfo,
+  shouldTrackPlaytime = false
 ): Promise<ExecResult> {
   const { dir, bin } = getGOGdlBin()
   return callRunner(
@@ -994,7 +996,9 @@ export async function runRunnerCommand(
     {
       ...options,
       verboseLogFile: gogdlLogFile
-    }
+    },
+    gameInfo,
+    shouldTrackPlaytime
   )
 }
 

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -860,7 +860,10 @@ export async function launch(
   // Log any launch information configured in Legendary's config.ini
   const { stdout } = await runLegendaryCommand(
     ['launch', appName, '--json', '--offline'],
-    createAbortController(appName)
+    createAbortController(appName),
+    undefined,
+    gameInfo,
+    true
   )
 
   appendFileSync(

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -860,10 +860,7 @@ export async function launch(
   // Log any launch information configured in Legendary's config.ini
   const { stdout } = await runLegendaryCommand(
     ['launch', appName, '--json', '--offline'],
-    createAbortController(appName),
-    undefined,
-    gameInfo,
-    true
+    createAbortController(appName)
   )
 
   appendFileSync(
@@ -924,7 +921,9 @@ export async function launch(
       onOutput: (output) => {
         appendFileSync(logFileLocation(appName), output)
       }
-    }
+    },
+    gameInfo,
+    true
   )
 
   deleteAbortController(appName)

--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -638,7 +638,9 @@ export const hasGame = (appName: string) => allGames.has(appName)
 export async function runRunnerCommand(
   commandParts: string[],
   abortController: AbortController,
-  options?: CallRunnerOptions
+  options?: CallRunnerOptions,
+  gameInfo?: GameInfo,
+  shouldTrackPlaytime = false
 ): Promise<ExecResult> {
   const { dir, bin } = getLegendaryBin()
   return callRunner(
@@ -648,6 +650,8 @@ export async function runRunnerCommand(
     {
       ...options,
       verboseLogFile: legendaryLogFile
-    }
+    },
+    gameInfo,
+    shouldTrackPlaytime
   )
 }

--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -268,7 +268,6 @@ export async function launchGame(
       if (runner === 'hyperplay') {
         //some games take a while to launch. 8 seconds seems to work well
         setTimeout(async () => injectProcess(gameInfo), 8000)
-        // trackPidPlaytime(child.pid, gameInfo)
       }
 
       await callRunner(

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -1503,3 +1503,27 @@ export {
 export const testingExportsUtils = {
   semverGt
 }
+
+// Return true if process following pid is running
+export const processIsRunning = (pid: number) => {
+  try {
+    return process.kill(pid, 0)
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  } catch (error: any) {
+    console.error(error)
+    return error.code === 'EPERM'
+  }
+}
+
+export const processIsClosed = async (pid: number) => {
+  return new Promise((resolve) => {
+    const check = () => {
+      if (!processIsRunning(pid)) {
+        resolve(true)
+      } else {
+        setTimeout(check, 1000)
+      }
+    }
+    check()
+  })
+}

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -1510,7 +1510,7 @@ export const processIsRunning = (pid: number) => {
     return process.kill(pid, 0)
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   } catch (error: any) {
-    console.error(error)
+    console.warn(error)
     return error.code === 'EPERM'
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1038,24 +1038,12 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.0.tgz#76467a94aa888aeb22aafa43eb6ff889df3a5a7f"
   integrity sha512-rBevIsj2nclStJ7AxTdfsa3ovHb1H+qApwrxcTVo+NNdeJiB9V75hsKfrkG5AwNcRUNxrPPiScGYCNmLMoh8pg==
 
-"@fortawesome/fontawesome-common-types@6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.0.tgz#88da2b70d6ca18aaa6ed3687832e11f39e80624b"
-  integrity sha512-HNii132xfomg5QVZw0HwXXpN22s7VBHQBv9CeOu9tfJnhsWQNd2lmTNi8CSrnw5B+5YOmzu1UoPAyxaXsJ6RgQ==
-
 "@fortawesome/fontawesome-svg-core@^6.1.1":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.2.0.tgz#11856eaf4dd1d865c442ddea1eed8ee855186ba2"
   integrity sha512-Cf2mAAeMWFMzpLC7Y9H1I4o3wEU+XovVJhTiNG8ZNgSQj53yl7OCJaS80K4YjrABWZzbAHVaoHE1dVJ27AAYXw==
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.2.0"
-
-"@fortawesome/fontawesome-svg-core@^6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.0.tgz#3727552eff9179506e9203d72feb5b1063c11a21"
-  integrity sha512-Bertv8xOiVELz5raB2FlXDPKt+m94MQ3JgDfsVbrqNpLU9+UE2E18GKjLKw+d3XbeYPqg1pzyQKGsrzbw+pPaw==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "6.4.0"
 
 "@fortawesome/free-brands-svg-icons@^6.1.1":
   version "6.2.0"
@@ -1071,13 +1059,6 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.2.0"
 
-"@fortawesome/free-regular-svg-icons@^6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.4.0.tgz#cacc53bd8d832d46feead412d9ea9ce80a55e13a"
-  integrity sha512-ZfycI7D0KWPZtf7wtMFnQxs8qjBXArRzczABuMQqecA/nXohquJ5J/RCR77PmY5qGWkxAZDxpnUFVXKwtY/jPw==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "6.4.0"
-
 "@fortawesome/free-solid-svg-icons@^6.1.1":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.2.0.tgz#8dcde48109354fd7a5ece8ea48d678bb91d4b5f0"
@@ -1085,24 +1066,10 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.2.0"
 
-"@fortawesome/free-solid-svg-icons@^6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz#48c0e790847fa56299e2f26b82b39663b8ad7119"
-  integrity sha512-kutPeRGWm8V5dltFP1zGjQOEAzaLZj4StdQhWVZnfGFCvAPVvHh8qk5bRrU4KXnRRRNni5tKQI9PBAdI6MP8nQ==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "6.4.0"
-
 "@fortawesome/react-fontawesome@^0.1.18":
   version "0.1.19"
   resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.19.tgz#2b36917578596f31934e71f92b7cf9c425fd06e4"
   integrity sha512-Hyb+lB8T18cvLNX0S3llz7PcSOAJMLwiVKBuuzwM/nI5uoBw+gQjnf9il0fR1C3DKOI5Kc79pkJ4/xB0Uw9aFQ==
-  dependencies:
-    prop-types "^15.8.1"
-
-"@fortawesome/react-fontawesome@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz#d90dd8a9211830b4e3c08e94b63a0ba7291ddcf4"
-  integrity sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==
   dependencies:
     prop-types "^15.8.1"
 


### PR DESCRIPTION
## Summary
adds game_title to install, update, and uninstall events

adds game launched and game closed events. the game closed event reports playtime as well

## Notes
for gogdl, hp, sideload runners, this tracks the child process 

for legendary this tracks the process of the pid outputted to stdout when launching a game

if a game exe launches a separate process then closes, the playtime reported will be < actual playtime
- we could inject on process name but it would be nice to not require the dev to provide this and for the games I tested, the above approach was working well

this works for browser and native games as well. it also reports the platform installed as this might be different that os and is useful for game devs

## Testing

Games tested:
- Defi kingdoms (hp browser)
- Kosium (hp native)
- dragon's dogma (gog)
- hundred day wine sim (epic)
- Kosium sideloaded (hp native)

### To test
1. Launch rudderstack
2. click hp dev
3. record live events
4. launch the app in dev mode
5. launch a game and wait ~30 seconds for the event to appear
6. close a game and wait
7. Repeat for several games

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
