### PR TITLE
[Fix] Uninstall games list layout shift

### DIFF
--- a/src/frontend/components/UI/Dialog/components/Dialog.tsx
+++ b/src/frontend/components/UI/Dialog/components/Dialog.tsx
@@ -60,21 +60,19 @@ export const Dialog: React.FC<DialogProps> = ({
   )
 
   return (
-    <div className="Dialog">
-      <dialog
-        className={`Dialog__element ${className}`}
-        ref={dialogRef}
-        onClick={onDialogClick}
-      >
-        {showCloseButton && (
-          <div className="Dialog__Close">
-            <button className="Dialog__CloseButton" onClick={onClose}>
-              <FontAwesomeIcon className="Dialog__CloseIcon" icon={faXmark} />
-            </button>
-          </div>
-        )}
-        {children}
-      </dialog>
-    </div>
+    <dialog
+      className={`Dialog__element ${className}`}
+      ref={dialogRef}
+      onClick={onDialogClick}
+    >
+      {showCloseButton && (
+        <div className="Dialog__Close">
+          <button className="Dialog__CloseButton" onClick={onClose}>
+            <FontAwesomeIcon className="Dialog__CloseIcon" icon={faXmark} />
+          </button>
+        </div>
+      )}
+      {children}
+    </dialog>
   )
 }

--- a/src/frontend/components/UI/Dialog/index.css
+++ b/src/frontend/components/UI/Dialog/index.css
@@ -1,12 +1,3 @@
-.Dialog {
-  padding: 0;
-  text-align: left;
-
-  --dialog-margin-horizontal: 32px;
-  --dialog-margin-vertical: 24px;
-  --dialog-gap: 24px;
-}
-
 .Dialog__element {
   top: 0;
   z-index: 8;
@@ -22,6 +13,12 @@
   transform: translateY(50px);
   transition: opacity 500ms, transform 500ms;
   max-width: min(700px, 85vw);
+
+  text-align: left;
+
+  --dialog-margin-horizontal: 32px;
+  --dialog-margin-vertical: 24px;
+  --dialog-gap: 24px;
 }
 
 .Dialog__element[open] {


### PR DESCRIPTION
Fixes empty game card sized div when uninstall modal is shown

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
