### PR TITLE
[FIX] Some fixes for #346

### DIFF
--- a/src/frontend/components/UI/Dialog/index.css
+++ b/src/frontend/components/UI/Dialog/index.css
@@ -1,7 +1,7 @@
 .Dialog {
   padding: 0;
   text-align: left;
-
+  position: absolute;
   --dialog-margin-horizontal: 32px;
   --dialog-margin-vertical: 24px;
   --dialog-gap: 24px;

--- a/src/frontend/components/UI/StopInstallationModal/index.tsx
+++ b/src/frontend/components/UI/StopInstallationModal/index.tsx
@@ -31,7 +31,7 @@ export default function StopInstallationModal(props: StopInstallProps) {
         <Checkbox
           ref={checkbox}
           onClick={() => console.log(checkbox.current?.checked)}
-          defaultChecked={true}
+          defaultChecked={false}
           type="secondary"
         >
           <div className="body">

--- a/src/frontend/screens/DownloadManager/components/ProgressHeader/index.tsx
+++ b/src/frontend/screens/DownloadManager/components/ProgressHeader/index.tsx
@@ -47,6 +47,9 @@ export default function ProgressHeader(props: {
     setAvgDownloadSpeed([...avgSpeed])
   }, [progress, props.state])
 
+  const showDownloadBar =
+    props.state !== 'idle' && props.appName && progress.percent
+
   return (
     <>
       <div className="progressHeader">
@@ -101,7 +104,7 @@ export default function ProgressHeader(props: {
           </div>
         </div>
       </div>
-      {props.state !== 'idle' && props.appName && (
+      {showDownloadBar && (
         <div className="downloadBar">
           <div className="downloadProgressStats">
             <p className="downloadStat" color="var(--text-default)">{`${

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -110,9 +110,11 @@ const GameCard = ({
   useEffect(() => {
     setIsLaunching(false)
     const updateGameInfo = async () => {
-      const newInfo = await getGameInfo(appName, runner)
-      if (newInfo) {
-        setGameInfo(newInfo)
+      if (!gameInfoFromProps) {
+        const newInfo = await getGameInfo(appName, runner)
+        if (newInfo) {
+          setGameInfo(newInfo)
+        }
       }
     }
     updateGameInfo()

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -88,6 +88,9 @@ export default React.memo(function Library(): JSX.Element {
   } = useContext(ContextProvider)
   const { t } = useTranslation()
 
+  const isGOGLoggedin = gog.username
+  const isEpicLoggedin = epic.username
+
   const filters: DropdownItemType[] = [
     {
       text: t('library.sortByStatus', 'Sort by Status'),
@@ -577,12 +580,16 @@ export default React.memo(function Library(): JSX.Element {
             <Tabs.Tab value="hyperplay">
               <div className="menu">{t('HyperPlay')}</div>
             </Tabs.Tab>
-            <Tabs.Tab value="legendary">
-              <div className="menu">EPIC</div>
-            </Tabs.Tab>
-            <Tabs.Tab value="gog">
-              <div className="menu">GOG</div>
-            </Tabs.Tab>
+            {isEpicLoggedin && (
+              <Tabs.Tab value="legendary">
+                <div className="menu">EPIC</div>
+              </Tabs.Tab>
+            )}
+            {isGOGLoggedin && (
+              <Tabs.Tab value="gog">
+                <div className="menu">GOG</div>
+              </Tabs.Tab>
+            )}
             <Tabs.Tab value="sideload">
               <div className="menu">{t('Other')}</div>
             </Tabs.Tab>


### PR DESCRIPTION
Some Fixes to the PR #346:

- Show only the filters for the stores you are logged in to.
- Set 'Keep files' to false by default when canceling a install.
- Do not show Zero progress when changing screens.
- Alternative fix to the empty card on library when a dialog is show.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
