### PR TITLE
[UI] Change X icon to "Exit Game" in browser game overlay

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -198,6 +198,7 @@
     },
     "Epic Games": "Epic Games",
     "error": "Error",
+    "exit_game": "Exit Game",
     "externalLink": {
         "dontAskAgain": "Don't ask again",
         "warning": "You are about to open an external link."

--- a/src/frontend/browserGame/BrowserExtensionManager/index.tsx
+++ b/src/frontend/browserGame/BrowserExtensionManager/index.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react'
 import BrowserExtensionManagerStyles from './index.module.scss'
 import { overlayExternalWalletConnectedMsg } from 'frontend/overlay/constants'
-import { Button, Images } from '@hyperplay/ui'
+import { Button } from '@hyperplay/ui'
 import { Runner } from 'common/types'
+import { useTranslation } from 'react-i18next'
 
 //Module type augmentation necessary to use experimental feature nodeintegrationinsubframes
 //https://www.electronjs.org/docs/latest/api/webview-tag
@@ -28,6 +29,7 @@ const BrowserExtensionManager = function ({
   const [showMmNotificationPage, setShowMmNotificationPage] = useState(false)
   const [extensionId, setExtensionId] = useState('')
   const [showMmPopupPage, setShowMmPopupPage] = useState(false)
+  const { t } = useTranslation()
 
   const getExtensionId = async () => {
     const extId = await window.api.getExtensionId()
@@ -99,9 +101,9 @@ const BrowserExtensionManager = function ({
               zIndex: 200
             }}
             type="secondary"
-            size="icon"
+            size="medium"
           >
-            <Images.CloseButton />
+            {t('exit_game', 'Exit Game')}
           </Button>
           <div className={BrowserExtensionManagerStyles.mmContainer}>
             {!showMmPopupPage ? (


### PR DESCRIPTION
Change X icon to "Exit Game" in browser game overlay

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
