### PR TITLE
[FIX] Platform selection on Add Game screen

### DIFF
--- a/src/frontend/screens/Library/components/InstallModal/SideloadDialog/Warning/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/SideloadDialog/Warning/index.tsx
@@ -8,14 +8,14 @@ const { ButtonText } = Typography
 const { WarningIcon } = Images
 
 export default function SideloadDialogWarning() {
-  const [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(true)
 
   return (
     <div className={styles.container}>
       {isOpen ? (
         <AlertCard
           style={{ maxWidth: 670 }}
-          onClose={() => setIsOpen(false)}
+          onClose={() => setIsOpen(!isOpen)}
           variant="danger"
           title={t('sideload.warningTitle', 'Important')}
           message={t(
@@ -24,7 +24,10 @@ export default function SideloadDialogWarning() {
           )}
         />
       ) : (
-        <div className={styles.titleContainer} onClick={() => setIsOpen(true)}>
+        <div
+          className={styles.titleContainer}
+          onClick={() => setIsOpen(!isOpen)}
+        >
           <WarningIcon />
           <ButtonText className={styles.title}>
             {t('sideload.warningTitle', 'Important')}

--- a/src/frontend/screens/Library/components/InstallModal/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/index.tsx
@@ -74,13 +74,13 @@ export default React.memo(function InstallModal({
   const platforms: AvailablePlatforms = [
     {
       name: 'Linux',
-      available: (isLinux && isLinuxNative) || isSideload,
+      available: isLinuxNative || (isSideload && isLinux),
       value: 'linux',
       icon: faLinux
     },
     {
       name: 'macOS',
-      available: (isMac && isMacNative) || isSideload,
+      available: isMacNative || (isSideload && isMac),
       value: 'Mac',
       icon: faApple
     },

--- a/src/frontend/screens/Library/components/InstallModal/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/index.tsx
@@ -74,13 +74,13 @@ export default React.memo(function InstallModal({
   const platforms: AvailablePlatforms = [
     {
       name: 'Linux',
-      available: isLinuxNative || (isSideload && isLinux),
+      available: isLinux && (isSideload || isLinuxNative),
       value: 'linux',
       icon: faLinux
     },
     {
       name: 'macOS',
-      available: isMacNative || (isSideload && isMac),
+      available: isMac && (isSideload || isMacNative),
       value: 'Mac',
       icon: faApple
     },


### PR DESCRIPTION
Fix the platform selection when sideloading a game.
I thought this was fixed already but I was mistaken.

![image](https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/assets/26871415/75f5e9e3-33ea-4507-a8e5-b69d7893b7a0)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
