### PR TITLE
[Fix] Launching of native linux games

### DIFF
--- a/src/backend/storeManagers/hyperplay/games.ts
+++ b/src/backend/storeManagers/hyperplay/games.ts
@@ -76,9 +76,9 @@ export function isNative(appName: string): boolean {
       return true
     }
 
-    const genericPlatform = handlePlatformReversed(platform)
+    const genericPlatform = handlePlatformReversed(platform).toLowerCase()
 
-    if (isMac && genericPlatform === 'Mac') {
+    if (isMac && genericPlatform === 'mac') {
       return true
     }
 


### PR DESCRIPTION
fixes hp game manager `isNative` returning false for native linux games due to 'Linux' === 'linux' returning false

Tested with Kosium (the only hp game with a linux native build) on linux

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
