### PR TITLE
[Feat] Browser game fullscreen hotkey

### DIFF
--- a/src/backend/main_window.ts
+++ b/src/backend/main_window.ts
@@ -78,7 +78,7 @@ export const createMainWindow = () => {
     }
   })
 
-  mainWindow.webContents.on('before-input-event', (event, input) => {
+  mainWindow.webContents?.on('before-input-event', (event, input) => {
     if (input.key === 'F11') backendEvents.emit('toggleFullscreen')
   })
 

--- a/src/backend/main_window.ts
+++ b/src/backend/main_window.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow, screen } from 'electron'
 import path from 'path'
 import { configStore } from './constants'
+import { backendEvents } from './backend_events'
 
 let mainWindow: BrowserWindow | null = null
 
@@ -75,6 +76,10 @@ export const createMainWindow = () => {
       // sandbox: false,
       preload: path.join(__dirname, 'preload.js')
     }
+  })
+
+  mainWindow.webContents.on('before-input-event', (event, input) => {
+    if (input.key === 'F11') backendEvents.emit('toggleFullscreen')
   })
 
   return mainWindow

--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -26,6 +26,7 @@ import { gameManagerMap } from '../index'
 const buildDir = resolve(__dirname, '../../build')
 import { hrtime } from 'process'
 import { trackEvent } from 'backend/metrics/metrics'
+import { backendEvents } from 'backend/backend_events'
 
 export async function getAppSettings(appName: string): Promise<GameSettings> {
   return (
@@ -79,6 +80,14 @@ const openNewBrowserGameWindow = async (
         nodeIntegration: true,
         preload: path.join(__dirname, 'preload.js')
       }
+    })
+
+    backendEvents.addListener('toggleFullscreen', () => {
+      if (browserGame.isDestroyed()) return
+
+      const fullscreenSize = browserGame.getSize()
+      browserGame.setFullScreen(!browserGame.isFullScreen())
+      browserGame.setSize(fullscreenSize[0], fullscreenSize[1])
     })
     browserGame.setIgnoreMouseEvents(false)
     browserGame.setMinimizable(true)

--- a/src/frontend/OverlayManager/index.tsx
+++ b/src/frontend/OverlayManager/index.tsx
@@ -53,7 +53,10 @@ const OverlayManager = function ({
     )
   }
 
-  if (!(isFullscreenOverlay(renderState) && !renderState.showBrowserGame)) {
+  if (
+    !(isFullscreenOverlay(renderState) && !renderState.showBrowserGame) &&
+    url === 'ignore'
+  ) {
     style.width = '100%'
     style.height = '100%'
   }


### PR DESCRIPTION
toggles fullscreen in browser games with F11 hotkey like regular browsers

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
