### PR TITLE
[Fix] Sentry init after ready

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -9,8 +9,7 @@ import {
   GamepadInputEvent,
   WineCommandArgs,
   ExecResult,
-  Runner,
-  MetricsOptInStatus
+  Runner
 } from 'common/types'
 import * as path from 'path'
 import {
@@ -169,13 +168,6 @@ function initSentry() {
 if (metricsAreEnabled()) {
   initSentry()
 }
-
-backendEvents.addListener(
-  'optInStatusChanged',
-  (newValue: MetricsOptInStatus) => {
-    if (newValue === MetricsOptInStatus.optedIn) initSentry()
-  }
-)
 
 app.commandLine?.appendSwitch('remote-debugging-port', '9222')
 


### PR DESCRIPTION
Metrics fail on initial opt in due to sentry init throwing from being called after app.whenReady() 

This removes the failing sentry init. This also means we won't get error logs on initial launch if the user opts in to metrics. We should consider an upstream PR to https://github.com/getsentry/sentry-electron to add an enable/disable toggle to sentry after init is called 

error message: 
```
Error occurred in handler for 'changeMetricsOptInStatus': SentryError: Sentry SDK should be initialized before the Electron app 'ready' event is fired
```

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
