### PR TITLE
[CI] Automate Flathub Releases

### DIFF
--- a/.github/workflows/release_flathub.yml
+++ b/.github/workflows/release_flathub.yml
@@ -46,8 +46,12 @@ jobs:
         run: git checkout -b "${{ github.ref_name }}"
         working-directory: ./xyz.hyperplay.HyperPlay
       - name: Publish flathub branch
-        run: git push --set-upstream origin ${{ github.ref_name }}
-        working-directory: ./xyz.hyperplay.HyperPlay
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          branch: ${{ github.ref_name }}
+          directory: xyz.hyperplay.HyperPlay
+          repository: xyz.hyperplay.HyperPlay
       - name: PR to flathub repo
         run: gh pr create --title ${{ github.ref_name }} --body ${{ github.ref_name }} --base main
         working-directory: ./xyz.hyperplay.HyperPlay

--- a/.github/workflows/release_flathub.yml
+++ b/.github/workflows/release_flathub.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: echo ref name.
-        run: echo "tag name ${{github.ref_name}}"
+        run: echo "tag name ${{ github.ref_name }}"
       - run: sudo apt-get install --no-install-recommends -y libarchive-tools libopenjp2-tools rpm snapcraft
       - name: Checkout repository.
         uses: actions/checkout@v3
@@ -43,8 +43,11 @@ jobs:
       - name: Update flathub release
         run: yarn release:updateFlathub:ci
       - name: Branch flathub repo
-        run: cd xyz.hyperplay.HyperPlay && git checkout -b "${{ github.ref_name }}"
+        run: git checkout -b "${{ github.ref_name }}"
+        working-directory: ./xyz.hyperplay.HyperPlay
       - name: Publish flathub branch
         run: git push --set-upstream origin ${{ github.ref_name }}
+        working-directory: ./xyz.hyperplay.HyperPlay
       - name: PR to flathub repo
         run: gh pr create --title ${{ github.ref_name }} --body ${{ github.ref_name }} --base main
+        working-directory: ./xyz.hyperplay.HyperPlay

--- a/.github/workflows/release_flathub.yml
+++ b/.github/workflows/release_flathub.yml
@@ -1,0 +1,48 @@
+name: Draft Release Flathub
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+  GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+
+jobs:
+  draft-releases:
+    runs-on: ubuntu-latest
+    steps:
+      - run: sudo apt-get install --no-install-recommends -y libarchive-tools libopenjp2-tools rpm snapcraft
+      - name: Checkout repository.
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+          token: ${{ secrets.pat }}
+      - name: Setup NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Reconfigure git to use HTTP authentication
+        run: >
+          git config --global url."https://github.com/".insteadOf
+          ssh://git@github.com/
+      - name: Authenticate with private NPM package
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+      - name: Install modules.
+        run: yarn
+      - name: Build tar.xz
+        run: yarn dist:linux:ci:flatpak
+      - name: Checkout flathub repository.
+        run: git clone https://github.com/flathub/xyz.hyperplay.HyperPlay.git
+      - name: Export tag name.
+        run: export RELEASE_VERSION=$GITHUB_REF_NAME
+      - name: Update flathub release
+        run: yarn updateFlathub
+      - name: Branch flathub repo
+        run: cd xyz.hyperplay.HyperPlay && git checkout -b "$GITHUB_REF_NAME"
+      - name: Publish flathub branch
+        run: git push --set-upstream origin $GITHUB_REF_NAME
+      - name: PR to flathub repo
+        run: gh pr create --title $GITHUB_REF_NAME --body $GITHUB_REF_NAME --base main

--- a/.github/workflows/release_flathub.yml
+++ b/.github/workflows/release_flathub.yml
@@ -58,5 +58,5 @@ jobs:
           directory: xyz.hyperplay.HyperPlay
           repository: flathub/xyz.hyperplay.HyperPlay
       - name: PR to flathub repo
-        run: sleep 5 && gh pr create --title ${{ github.ref_name }} --body ${{ github.ref_name }} --base master
+        run: sleep 5 && gh pr create --title ${{ github.ref_name }} --body ${{ github.ref_name }} --base master --head ${{ github.ref_name }}
         working-directory: ./xyz.hyperplay.HyperPlay

--- a/.github/workflows/release_flathub.yml
+++ b/.github/workflows/release_flathub.yml
@@ -46,8 +46,11 @@ jobs:
         run: git checkout -b "${{ github.ref_name }}"
         working-directory: ./xyz.hyperplay.HyperPlay
       - name: Commit changes
-        run: git commit -m "changes for ${{ github.ref_name }}"
-        working-directory: ./xyz.hyperplay.HyperPlay
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: 'changes for ${{ github.ref_name }}'
+          add: '*'
+          cwd: './xyz.hyperplay.HyperPlay/'
       - name: Publish flathub branch
         uses: ad-m/github-push-action@master
         with:

--- a/.github/workflows/release_flathub.yml
+++ b/.github/workflows/release_flathub.yml
@@ -14,6 +14,8 @@ jobs:
   draft-releases:
     runs-on: ubuntu-latest
     steps:
+      - name: echo ref name.
+        run: echo "tag name ${{github.ref_name}}"
       - run: sudo apt-get install --no-install-recommends -y libarchive-tools libopenjp2-tools rpm snapcraft
       - name: Checkout repository.
         uses: actions/checkout@v3
@@ -37,12 +39,12 @@ jobs:
       - name: Checkout flathub repository.
         run: git clone https://github.com/flathub/xyz.hyperplay.HyperPlay.git
       - name: Export tag name.
-        run: export RELEASE_VERSION=$GITHUB_REF_NAME
+        run: export RELEASE_VERSION=${{ github.ref_name }}
       - name: Update flathub release
         run: yarn release:updateFlathub:ci
       - name: Branch flathub repo
-        run: cd xyz.hyperplay.HyperPlay && git checkout -b "$GITHUB_REF_NAME"
+        run: cd xyz.hyperplay.HyperPlay && git checkout -b "${{ github.ref_name }}"
       - name: Publish flathub branch
-        run: git push --set-upstream origin $GITHUB_REF_NAME
+        run: git push --set-upstream origin ${{ github.ref_name }}
       - name: PR to flathub repo
-        run: gh pr create --title $GITHUB_REF_NAME --body $GITHUB_REF_NAME --base main
+        run: gh pr create --title ${{ github.ref_name }} --body ${{ github.ref_name }} --base main

--- a/.github/workflows/release_flathub.yml
+++ b/.github/workflows/release_flathub.yml
@@ -45,19 +45,12 @@ jobs:
       - name: Branch flathub repo
         run: git checkout -b "${{ github.ref_name }}"
         working-directory: ./xyz.hyperplay.HyperPlay
-      - name: Publish flathub branch
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.WORKFLOW_TOKEN }}
-          branch: ${{ github.ref_name }}
-          directory: xyz.hyperplay.HyperPlay
-          repository: flathub/xyz.hyperplay.HyperPlay
-      - name: Commit changes
-        uses: EndBug/add-and-commit@v9
-        with:
-          message: 'changes for ${{ github.ref_name }}'
-          add: '*'
-          cwd: './xyz.hyperplay.HyperPlay/'
+      - name: Commit files
+        run: |
+          git config --local user.email "27568879+BrettCleary@users.noreply.github.com"
+          git config --local user.name "BrettCleary"
+          git commit -a -m "changes for ${{ github.ref_name }}"
+        working-directory: ./xyz.hyperplay.HyperPlay
       - name: Push updated flathub branch
         uses: ad-m/github-push-action@master
         with:

--- a/.github/workflows/release_flathub.yml
+++ b/.github/workflows/release_flathub.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Branch flathub repo
         run: git checkout -b "${{ github.ref_name }}"
         working-directory: ./xyz.hyperplay.HyperPlay
+      - name: Commit changes
+        run: git commit -m "changes for ${{ github.ref_name }}"
+        working-directory: ./xyz.hyperplay.HyperPlay
       - name: Publish flathub branch
         uses: ad-m/github-push-action@master
         with:

--- a/.github/workflows/release_flathub.yml
+++ b/.github/workflows/release_flathub.yml
@@ -9,6 +9,7 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
   GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+  RELEASE_VERSION: ${{ github.ref_name }}
 
 jobs:
   draft-releases:
@@ -38,14 +39,12 @@ jobs:
         run: yarn dist:linux:ci:flatpak
       - name: Checkout flathub repository.
         run: git clone https://github.com/flathub/xyz.hyperplay.HyperPlay.git
-      - name: Export tag name.
-        run: export RELEASE_VERSION=${{ github.ref_name }}
       - name: Update flathub release
-        run: yarn release:updateFlathub:ci
+        run: export RELEASE_VERSION=${{ github.ref_name }} && yarn release:updateFlathub:ci
       - name: Branch flathub repo
         run: git checkout -b "${{ github.ref_name }}"
         working-directory: ./xyz.hyperplay.HyperPlay
-      - name: Commit files
+      - name: Commit files to xyz.hyperplay.HyperPlay
         run: |
           git config --local user.email "27568879+BrettCleary@users.noreply.github.com"
           git config --local user.name "BrettCleary"
@@ -59,5 +58,5 @@ jobs:
           directory: xyz.hyperplay.HyperPlay
           repository: flathub/xyz.hyperplay.HyperPlay
       - name: PR to flathub repo
-        run: gh pr create --title ${{ github.ref_name }} --body ${{ github.ref_name }} --base main
+        run: sleep 5 && gh pr create --title ${{ github.ref_name }} --body ${{ github.ref_name }} --base master
         working-directory: ./xyz.hyperplay.HyperPlay

--- a/.github/workflows/release_flathub.yml
+++ b/.github/workflows/release_flathub.yml
@@ -45,13 +45,20 @@ jobs:
       - name: Branch flathub repo
         run: git checkout -b "${{ github.ref_name }}"
         working-directory: ./xyz.hyperplay.HyperPlay
+      - name: Publish flathub branch
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          branch: ${{ github.ref_name }}
+          directory: xyz.hyperplay.HyperPlay
+          repository: flathub/xyz.hyperplay.HyperPlay
       - name: Commit changes
         uses: EndBug/add-and-commit@v9
         with:
           message: 'changes for ${{ github.ref_name }}'
           add: '*'
           cwd: './xyz.hyperplay.HyperPlay/'
-      - name: Publish flathub branch
+      - name: Push updated flathub branch
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.WORKFLOW_TOKEN }}

--- a/.github/workflows/release_flathub.yml
+++ b/.github/workflows/release_flathub.yml
@@ -51,7 +51,7 @@ jobs:
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           branch: ${{ github.ref_name }}
           directory: xyz.hyperplay.HyperPlay
-          repository: xyz.hyperplay.HyperPlay
+          repository: flathub/xyz.hyperplay.HyperPlay
       - name: PR to flathub repo
         run: gh pr create --title ${{ github.ref_name }} --body ${{ github.ref_name }} --base main
         working-directory: ./xyz.hyperplay.HyperPlay

--- a/.github/workflows/release_flathub.yml
+++ b/.github/workflows/release_flathub.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Export tag name.
         run: export RELEASE_VERSION=$GITHUB_REF_NAME
       - name: Update flathub release
-        run: yarn updateFlathub
+        run: yarn release:updateFlathub:ci
       - name: Branch flathub repo
         run: cd xyz.hyperplay.HyperPlay && git checkout -b "$GITHUB_REF_NAME"
       - name: Publish flathub branch

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ vite-plugin-electron.log
 # these can be reconfigured if we ever want to adopt yarn berry
 .yarnrc.yml 
 .yarn/
+
+flathub/update-flathub.js
+xyz.hyperplay.HyperPlay

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HyperPlay
+# HyperPlay-Test
 
 HyperPlay is an Open Source Game Launcher for Linux, Windows and macOS with Web3 features.
 It was conceived as a fork of [Heroic Games Launcher](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher), so it keeps its features but also add new ones.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HyperPlay-Test
+# HyperPlay
 
 HyperPlay is an Open Source Game Launcher for Linux, Windows and macOS with Web3 features.
 It was conceived as a fork of [Heroic Games Launcher](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher), so it keeps its features but also add new ones.
@@ -42,7 +42,7 @@ Download the `hyperplay.x.x.x_amd64.deb` from the Releases section
 sudo dpkg -i hyperplay.x.x.x_amd64.deb
 ```
 
-#### Other Distributions (tar.xz)
+#### Other Distributions (TAR.XZ)
 
 Since these two distribution formats don't have a form of dependency management, make sure the `curl` command is available. You might run into weird issues if it's not.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Download the `hyperplay.x.x.x_amd64.deb` from the Releases section
 sudo dpkg -i hyperplay.x.x.x_amd64.deb
 ```
 
-#### Other Distributions (TAR.XZ)
+#### Other Distributions (tar.xz)
 
 Since these two distribution formats don't have a form of dependency management, make sure the `curl` command is available. You might run into weird issues if it's not.
 

--- a/flathub/update-flathub.ts
+++ b/flathub/update-flathub.ts
@@ -8,7 +8,9 @@ console.log('updating url in xyz.hyperplay.HyperPlay.yml')
 const ymlFilePath = './xyz.hyperplay.HyperPlay/xyz.hyperplay.HyperPlay.yml'
 let hpYml = fs.readFileSync(ymlFilePath).toString()
 
-const releaseString = `https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/releases/download/${process.env.RELEASE_VERSION}/hyperplay-${process.env.RELEASE_VERSION}.tar.xz`
+const releaseString = `https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/releases/download/${
+  process.env.RELEASE_VERSION
+}/hyperplay-${process.env.RELEASE_VERSION?.substring(1)}.tar.xz`
 hpYml = hpYml.replace(
   /https:\/\/github.com\/HyperPlay-Gaming\/hyperplay-desktop-client\/releases\/download\/v.*..*..*\/hyperplay-.*..*..*.tar.xz/,
   releaseString

--- a/flathub/update-flathub.ts
+++ b/flathub/update-flathub.ts
@@ -1,0 +1,52 @@
+import * as fs from 'fs'
+import * as crypto from 'crypto'
+
+console.log('tag name: ', process.env.RELEASE_VERSION)
+
+// update url in xyz.hyperplay.HyperPlay.yml
+console.log('updating url in xyz.hyperplay.HyperPlay.yml')
+const ymlFilePath = './xyz.hyperplay.HyperPlay/xyz.hyperplay.HyperPlay.yml'
+let hpYml = fs.readFileSync(ymlFilePath).toString()
+
+const releaseString = `https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/releases/download/${process.env.RELEASE_VERSION}/hyperplay-${process.env.RELEASE_VERSION}.tar.xz`
+hpYml = hpYml.replace(
+  /https:\/\/github.com\/HyperPlay-Gaming\/hyperplay-desktop-client\/releases\/download\/v.*..*..*\/hyperplay-.*..*..*.tar.xz/,
+  releaseString
+)
+
+// update hash in xyz.hyperplay.HyperPlay.yml
+console.log('updating hash in xyz.hyperplay.HyperPlay.yml')
+const tarXzFilePath = fs
+  .readdirSync('./dist')
+  .find((fileName) => fileName.endsWith('.tar.xz'))
+if (tarXzFilePath === undefined) {
+  throw 'Tar XZ could not be found!'
+}
+const outputContent = fs.readFileSync('./dist/' + tarXzFilePath)
+const hashSum = crypto.createHash('sha512')
+hashSum.update(outputContent)
+const sha512 = hashSum.digest('hex')
+
+hpYml = hpYml.replace(/sha512: [0-9, a-f]{128}/, `sha512: ${sha512}`)
+
+fs.writeFileSync(ymlFilePath, hpYml)
+
+// update release version and date on xml tag in xyz.hyperplay.HyperPlay.metainfo.xml
+console.log(
+  'updating release version and date on xml tag in xyz.hyperplay.HyperPlay.metainfo.xml'
+)
+const xmlFilePath =
+  './xyz.hyperplay.HyperPlay/xyz.hyperplay.HyperPlay.metainfo.xml'
+let hpXml = fs.readFileSync(xmlFilePath).toString()
+const date = new Date()
+const isoDate = date.toISOString().slice(0, 10)
+
+hpXml = hpXml.replace(
+  /release version="v.*..*..*" date="[0-9]{4}-[0-9]{2}-[0-9]{2}"/,
+  `release version="${process.env.RELEASE_VERSION}" date="${isoDate}"`
+)
+
+fs.writeFileSync(xmlFilePath, hpXml)
+console.log(
+  'Finished updating flathub release! Be sure to update release notes manually before merging.'
+)

--- a/package.json
+++ b/package.json
@@ -236,6 +236,7 @@
     "test:e2ePackaged": "cross-env TEST_PACKAGED=true yarn test:e2e",
     "manualTestProxyJest": "jest mmExtIntegration.test.ts",
     "release:linux": "export NODE_ENV_ELECTRON_VITE=production && vite build && electron-builder -p always --linux deb rpm pacman tar.xz",
+    "release:updateFlathub:ci": "tsc flathub/update-flathub.ts --skipLibCheck && node flathub/update-flathub.js",
     "release:mac": "export NODE_ENV_ELECTRON_VITE=production && vite build && electron-builder -p always --mac --x64 --arm64",
     "release:win": "cross-env NODE_ENV_ELECTRON_VITE=production vite build && electron-builder -p always --win nsis",
     "dist:linux": "export NODE_ENV_ELECTRON_VITE=production && vite build && electron-builder --linux",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5827,18 +5827,6 @@ electron-fetch@^1.7.2:
   dependencies:
     encoding "^0.1.13"
 
-electron-osx-sign@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/electron-osx-sign/-/electron-osx-sign-0.6.0.tgz#9b69c191d471d9458ef5b1e4fdd52baa059f1bb8"
-  integrity sha512-+hiIEb2Xxk6eDKJ2FFlpofCnemCbjbT5jz+BKGpVBrRNT3kWTGs4DfNX6IzGwgi33hUcXF+kFs9JW+r6Wc1LRg==
-  dependencies:
-    bluebird "^3.5.0"
-    compare-version "^0.1.2"
-    debug "^2.6.8"
-    isbinaryfile "^3.0.2"
-    minimist "^1.2.0"
-    plist "^3.0.1"
-
 electron-playwright-helpers@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/electron-playwright-helpers/-/electron-playwright-helpers-1.5.4.tgz#f64c8cad21c19231e26b3677fc34aaeafad6de4c"


### PR DESCRIPTION
automatically generate flathub PR on release tag

Known issues:
- the build will have to be re-run in buildbot.flathub.org after the release is published since it uses the release tar.xz download url and cannot access it if the release is still in draft
- the sha512 hash calculated was not able to be tested and compared for equality between electron builder and the tar xz built in this gha. if the build fails, check this as well

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
