### PR TITLE
[Feature] Access codes

### DIFF
--- a/src/backend/constants.ts
+++ b/src/backend/constants.ts
@@ -88,9 +88,14 @@ const eventsToCloseMetaMaskPopupOn = [
 ]
 const valistListingsApiUrl = 'https://developers.hyperplay.xyz/api/v1/listings'
 const mainReleaseChannelName = 'main'
+const valistBaseApiUrlv1 = 'https://api.valist.io/v1'
 
 export function getValistListingApiUrl(projectId: string) {
   return `${valistListingsApiUrl}/${projectId}`
+}
+
+export function getValidateLicenseKeysApiUrl() {
+  return `${valistBaseApiUrlv1}/license_keys/validate`
 }
 
 /**

--- a/src/backend/downloadmanager/utils.ts
+++ b/src/backend/downloadmanager/utils.ts
@@ -20,7 +20,8 @@ async function installQueueElement(params: InstallParams): Promise<{
     runner,
     installLanguage,
     platformToInstall,
-    channelName
+    channelName,
+    accessCode
   } = params
   const { title } = gameManagerMap[runner].getGameInfo(appName)
 
@@ -87,7 +88,8 @@ async function installQueueElement(params: InstallParams): Promise<{
         sdlList,
         platformToInstall: installPlatform,
         installLanguage,
-        channelName
+        channelName,
+        accessCode
       })
 
     const { status, error } = await installInstance()

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -7,7 +7,8 @@ import 'i18next'
 import {
   WineSupport,
   SystemRequirements,
-  SupportedPlatform as AppPlatforms
+  SupportedPlatform as AppPlatforms,
+  PlatformsMetaInterface
 } from '@valist/sdk/dist/typesShared'
 import { Channel } from '@valist/sdk/dist/typesApi'
 
@@ -22,6 +23,20 @@ export type {
   SupportedPlatform as AppPlatforms,
   PlatformConfig
 } from '@valist/sdk/dist/typesShared'
+
+declare module '@valist/sdk/dist/typesApi' {
+  interface Channel {
+    license_config: {
+      id: number
+      access_codes: boolean
+    }
+  }
+}
+
+export interface LicenseConfigValidateResult {
+  valid: boolean
+  platforms: PlatformsMetaInterface
+}
 
 // fix for i18next https://www.i18next.com/overview/typescript#argument-of-type-defaulttfuncreturn-is-not-assignable-to-parameter-of-type-xyz
 declare module 'i18next' {
@@ -279,6 +294,7 @@ export interface InstallArgs {
   sdlList?: string[]
   installLanguage?: string
   channelName?: string
+  accessCode?: string
 }
 
 export interface InstallParams extends InstallArgs {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -175,6 +175,8 @@ export interface GameInfo {
   //data schema version
   v?: string
   account_name?: string
+  //key is channel_id, value is last access code used
+  accessCodesCache?: Record<string, string>
 }
 
 export interface GameSettings {

--- a/src/frontend/helpers/library.ts
+++ b/src/frontend/helpers/library.ts
@@ -26,6 +26,7 @@ type InstallArgs = {
   installLanguage?: string
   showDialogModal: (options: DialogModalOptions) => void
   channelName?: string
+  accessCode?: string
 }
 
 async function install({
@@ -38,7 +39,8 @@ async function install({
   installDlcs = false,
   installLanguage = 'en-US',
   platformToInstall = 'Windows',
-  channelName
+  channelName,
+  accessCode
 }: InstallArgs) {
   if (!installPath) {
     console.error('installPath is undefined')
@@ -97,7 +99,8 @@ async function install({
     runner,
     platformToInstall,
     gameInfo,
-    channelName
+    channelName,
+    accessCode
   })
 }
 

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -565,14 +565,14 @@ export default function DownloadDialog({
       <DialogFooter>
         <Button
           type="tertiary"
-          size="large"
+          size="medium"
           onClick={async () => handleInstall('import')}
         >
           {t('button.import')}
         </Button>
         <Button
           type="secondary"
-          size="large"
+          size="medium"
           onClick={async () => handleInstall()}
           disabled={!readyToInstall}
         >

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -59,6 +59,7 @@ interface Props {
   children: React.ReactNode
   gameInfo: GameInfo
   channelNameToInstall: string
+  accessCode: string
 }
 
 type DiskSpaceInfo = {
@@ -112,7 +113,8 @@ export default function DownloadDialog({
   children,
   gameInfo,
   crossoverBottle,
-  channelNameToInstall
+  channelNameToInstall,
+  accessCode
 }: Props) {
   const previousProgress = JSON.parse(
     storage.getItem(appName) || '{}'
@@ -215,7 +217,8 @@ export default function DownloadDialog({
       installLanguage,
       platformToInstall,
       showDialogModal: () => backdropClick(),
-      channelName: channelNameToInstall
+      channelName: channelNameToInstall,
+      accessCode
     })
   }
 

--- a/src/frontend/screens/Library/components/InstallModal/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/index.tsx
@@ -27,6 +27,7 @@ import { SelectField } from 'frontend/components/UI'
 import { useTranslation } from 'react-i18next'
 import { getPlatformName } from 'frontend/helpers'
 import { translateChannelName } from 'frontend/screens/Library/constants'
+import TextInputField from 'frontend/components/UI/TextInputField'
 
 type Props = {
   appName: string
@@ -55,6 +56,7 @@ export default React.memo(function InstallModal({
   const [wineVersion, setWineVersion] = useState<WineInstallation>()
   const [wineVersionList, setWineVersionList] = useState<WineInstallation[]>([])
   const [crossoverBottle, setCrossoverBottle] = useState('')
+  const [accessCode, setAccessCode] = useState('')
 
   const initChannelName =
     gameInfo?.channels && Object.keys(gameInfo?.channels).length > 0
@@ -68,11 +70,9 @@ export default React.memo(function InstallModal({
   const isLinux = platform === 'linux'
   const isSideload = runner === 'sideload'
 
-  const channelPlatforms =
-    (gameInfo !== null &&
-      gameInfo.channels !== undefined &&
-      gameInfo.channels[channelNameToInstall].release_meta.platforms) ??
-    []
+  const selectedChannel = gameInfo?.channels?.[channelNameToInstall]
+
+  const channelPlatforms = selectedChannel?.release_meta.platforms ?? []
   const hpPlatforms = Object.keys(channelPlatforms) as AppPlatforms[]
   const isHpGame = runner === 'hyperplay'
 
@@ -187,24 +187,34 @@ export default React.memo(function InstallModal({
 
   function channelNameSelection() {
     return (
-      <SelectField
-        label={`${t('game.selectChannelName', 'Select Channel Name')}:`}
-        htmlId="channelNameSelect"
-        value={channelNameToInstall}
-        onChange={(e) => setChannelNameToInstall(e.target.value)}
-      >
-        {gameInfo?.channels !== undefined
-          ? Object.keys(gameInfo.channels).map((p, i) => {
-              if (!gameInfo.channels) return <div>error</div>
-              const channel_i = gameInfo.channels[p]
-              return (
-                <option value={p} key={i}>
-                  {translateChannelName(channel_i.channel_name, t)}
-                </option>
-              )
-            })
-          : null}
-      </SelectField>
+      <>
+        <SelectField
+          label={`${t('game.selectChannelName', 'Select Channel Name')}:`}
+          htmlId="channelNameSelect"
+          value={channelNameToInstall}
+          onChange={(e) => setChannelNameToInstall(e.target.value)}
+        >
+          {gameInfo?.channels !== undefined
+            ? Object.keys(gameInfo.channels).map((p, i) => {
+                if (!gameInfo.channels) return <div>error</div>
+                const channel_i = gameInfo.channels[p]
+                return (
+                  <option value={p} key={i}>
+                    {translateChannelName(channel_i.channel_name, t)}
+                  </option>
+                )
+              })
+            : null}
+        </SelectField>
+        {selectedChannel?.license_config.access_codes ? (
+          <TextInputField
+            placeholder={'Enter access code'}
+            value={accessCode}
+            onChange={(ev) => setAccessCode(ev.target.value)}
+            htmlId="access_code_input"
+          ></TextInputField>
+        ) : null}
+      </>
     )
   }
 
@@ -229,6 +239,7 @@ export default React.memo(function InstallModal({
             gameInfo={gameInfo}
             crossoverBottle={crossoverBottle}
             channelNameToInstall={channelNameToInstall}
+            accessCode={accessCode}
           >
             {platformSelection()}
             {runner === 'hyperplay' ? channelNameSelection() : null}


### PR DESCRIPTION
Access code gate games on install

Stores access code locally in `gameInfo.accessCodesCache` for use during update

UI uses the existing text input field in the app. I think we should update the install modal designs to latest design on a separate branch

### Testing
here are some access codes to test the Kosium Beta channel with 
H87YS0VDATNM
6915SC7P4UGY
0I0EJBVJI865
KFDC8T9RKT0H
WW6YGNBCUE9H
M2SSQMZFMO8E
J1W0871M1B9D
IAW4NTI2LBFA
OPBCBE50I1GB
2EJ2XQ0COTRN

### Screenshots
![image](https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/assets/27568879/7c76d611-626f-4ad3-93ab-6328cf67e9d9)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
