### PR TITLE
[Fix] rm encodeUri of already formed url

### DIFF
--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -1244,7 +1244,7 @@ export async function downloadFile(
 
   let connections = 1
   try {
-    const response = await axios.head(encodeURI(url))
+    const response = await axios.head(url)
     const cdnCache = response.headers['cdn-cache']
     const isCached = cdnCache === 'HIT' || cdnCache === 'STALE'
     if (isCached) {


### PR DESCRIPTION
an already formed url doesn't need encodeURI

this can cause issues for certain urls which then throws a "can't get headers" error

for instance

```
const a = encodeURI('https://gateway.valist.io/ipfs/bafybeia4d6wvhmmokscxubsxf4xjswzh4yqdotnk7ozutzymabq5rm2f24/windows_amd64/Thetan%2BLauncher%2BSetup%2B1.0.5.zip')

console.log(a)

//ouputs: "https://gateway.valist.io/ipfs/bafybeia4d6wvhmmokscxubsxf4xjswzh4yqdotnk7ozutzymabq5rm2f24/windows_amd64/Thetan%252BLauncher%252BSetup%252B1.0.5.zip"
//ERROR! not the same as a
```

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
