### PR TITLE
[macOS - Feat] Add support for Apple Gaming porting toolkit

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -672,6 +672,7 @@
         },
         "select_theme": "Select Theme",
         "showfps": "Show FPS (DX9, 10 and 11)",
+        "showMetalOverlay": "Show Stats Overlay",
         "start-in-tray": "Start Minimized",
         "steamruntime": "Use Steam Runtime",
         "winecrossoverbottle": "CrossOver Bottle",

--- a/src/backend/__tests__/utils.test.ts
+++ b/src/backend/__tests__/utils.test.ts
@@ -198,7 +198,7 @@ describe('backend/utils.ts', () => {
         getBytesFromMB(totalSizeMB),
         lastProgressTime
       )
-      expect(etaString).toEqual('00:00:05')
+      expect(etaString).toEqual('00:00:04')
     })
 
     test('normal download minutes', () => {

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -1,12 +1,5 @@
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  writeFileSync
-} from 'graceful-fs'
-import { homedir, userInfo as user } from 'os'
-import { parse as plistParse, PlistObject } from 'plist'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'graceful-fs'
+import { userInfo as user } from 'os'
 
 import {
   AppSettings,
@@ -20,19 +13,23 @@ import {
   defaultWinePrefix,
   gamesConfigPath,
   installPath,
-  toolsPath,
   userHome,
   isFlatpak,
   isMac,
   isWindows,
-  getSteamLibraries,
   getSteamCompatFolder,
   configStore
 } from './constants'
-import { execAsync } from './utils'
-import { execSync } from 'child_process'
+
 import { logError, logInfo, LogPrefix } from './logger/logger'
-import { dirname, join } from 'path'
+import {
+  getCrossover,
+  getDefaultWine,
+  getGamingPortingToolkitWine,
+  getLinuxWineSet,
+  getWineOnMac,
+  getWineskinWine
+} from './utils/compatibility_layers'
 
 /**
  * This class does config handling.
@@ -127,174 +124,26 @@ abstract class GlobalConfig {
   }
 
   /**
-   * Loads the default wine installation path and version.
-   *
-   * @returns Promise<WineInstallation>
-   */
-  public getDefaultWine(): WineInstallation {
-    const defaultWine: WineInstallation = {
-      bin: '',
-      name: 'Default Wine - Not Found',
-      type: 'wine'
-    }
-
-    try {
-      let stdout = execSync(`which wine`).toString()
-      const wineBin = stdout.split('\n')[0]
-      defaultWine.bin = wineBin
-
-      stdout = execSync(`wine --version`).toString()
-      const version = stdout.split('\n')[0]
-      defaultWine.name = `Wine Default - ${version}`
-
-      return {
-        ...defaultWine,
-        ...this.getWineExecs(wineBin)
-      }
-    } catch {
-      return defaultWine
-    }
-  }
-
-  /**
-   * Detects Wine installed on home application folder on Mac
-   *
+   * Detects Wine on Mac
    * @returns Promise<Set<WineInstallation>>
-   */
-  public async getWineOnMac(): Promise<Set<WineInstallation>> {
-    const wineSet = new Set<WineInstallation>()
-    if (!isMac) {
-      return wineSet
-    }
-
-    const winePaths = new Set<string>()
-
-    // search for wine installed on $HOME/Library/Application Support/hyperplay/tools/wine
-    const wineToolsPath = `${toolsPath}/wine/`
-    if (existsSync(wineToolsPath)) {
-      readdirSync(wineToolsPath).forEach((path) => {
-        winePaths.add(join(wineToolsPath, path))
-      })
-    }
-
-    // search for wine installed around the system
-    await execAsync('mdfind kMDItemCFBundleIdentifier = "*.wine"').then(
-      async ({ stdout }) => {
-        stdout.split('\n').forEach((winePath) => {
-          winePaths.add(winePath)
-        })
-      }
-    )
-
-    winePaths.forEach((winePath) => {
-      const infoFilePath = join(winePath, 'Contents/Info.plist')
-      if (winePath && existsSync(infoFilePath)) {
-        const info = plistParse(
-          readFileSync(infoFilePath, 'utf-8')
-        ) as PlistObject
-        const version = info['CFBundleShortVersionString'] || ''
-        const name = info['CFBundleName'] || ''
-        const wineBin = join(winePath, '/Contents/Resources/wine/bin/wine64')
-        if (existsSync(wineBin)) {
-          wineSet.add({
-            ...this.getWineExecs(wineBin),
-            lib: `${winePath}/Contents/Resources/wine/lib`,
-            lib32: `${winePath}/Contents/Resources/wine/lib`,
-            bin: wineBin,
-            name: `${name} - ${version}`,
-            type: 'wine',
-            ...this.getWineExecs(wineBin)
-          })
-        }
-      }
-    })
-
-    return wineSet
-  }
-
-  public async getWineskinWine(): Promise<Set<WineInstallation>> {
-    const wineSet = new Set<WineInstallation>()
-    if (!isMac) {
-      return wineSet
-    }
-    const wineSkinPath = `${userHome}/Applications/Wineskin`
-    if (existsSync(wineSkinPath)) {
-      const apps = readdirSync(wineSkinPath)
-      for (const app of apps) {
-        if (app.includes('.app')) {
-          const wineBin = `${userHome}/Applications/Wineskin/${app}/Contents/SharedSupport/wine/bin/wine64`
-          if (existsSync(wineBin)) {
-            try {
-              const { stdout: out } = await execAsync(`'${wineBin}' --version`)
-              const version = out.split('\n')[0]
-              wineSet.add({
-                ...this.getWineExecs(wineBin),
-                lib: `${userHome}/Applications/Wineskin/${app}/Contents/SharedSupport/wine/lib`,
-                lib32: `${userHome}/Applications/Wineskin/${app}/Contents/SharedSupport/wine/lib`,
-                name: `Wineskin - ${version}`,
-                type: 'wine',
-                bin: wineBin
-              })
-            } catch (error) {
-              logError(
-                `Error getting wine version for ${wineBin}`,
-                LogPrefix.GlobalConfig
-              )
-            }
-          }
-        }
-      }
-    }
-    return wineSet
-  }
-
-  /**
-   * Detects CrossOver installs on Mac
-   *
-   * @returns Promise<Set<WineInstallation>>
-   */
-  public async getCrossover(): Promise<Set<WineInstallation>> {
-    const crossover = new Set<WineInstallation>()
-
-    if (!isMac) {
-      return crossover
-    }
-
-    await execAsync(
-      'mdfind kMDItemCFBundleIdentifier = "com.codeweavers.CrossOver"'
-    ).then(async ({ stdout }) => {
-      stdout.split('\n').forEach((crossoverMacPath) => {
-        const infoFilePath = join(crossoverMacPath, 'Contents/Info.plist')
-        if (crossoverMacPath && existsSync(infoFilePath)) {
-          const info = plistParse(
-            readFileSync(infoFilePath, 'utf-8')
-          ) as PlistObject
-          const version = info['CFBundleShortVersionString'] || ''
-          const crossoverWineBin = join(
-            crossoverMacPath,
-            'Contents/SharedSupport/CrossOver/bin/wine'
-          )
-          crossover.add({
-            bin: crossoverWineBin,
-            name: `CrossOver - ${version}`,
-            type: 'crossover',
-            ...this.getWineExecs(crossoverWineBin)
-          })
-        }
-      })
-    })
-    return crossover
-  }
-
+   * @memberof GlobalConfig
+   **/
   public async getMacOsWineSet(): Promise<Set<WineInstallation>> {
     if (!isMac) {
       return new Set<WineInstallation>()
     }
 
-    const crossover = await this.getCrossover()
-    const wineOnMac = await this.getWineOnMac()
-    const wineskinWine = await this.getWineskinWine()
-    return new Set([...crossover, ...wineOnMac, ...wineskinWine])
+    const crossover = await getCrossover()
+    const wineOnMac = await getWineOnMac()
+    const wineskinWine = await getWineskinWine()
+    const gamingPortingToolkitWine = await getGamingPortingToolkitWine()
+
+    return new Set([
+      ...gamingPortingToolkitWine,
+      ...crossover,
+      ...wineOnMac,
+      ...wineskinWine
+    ])
   }
 
   /**
@@ -311,123 +160,9 @@ abstract class GlobalConfig {
       return [...macOsWineSet]
     }
 
-    if (!existsSync(`${toolsPath}/wine`)) {
-      mkdirSync(`${toolsPath}/wine`, { recursive: true })
-    }
+    const linuxWineSet = await getLinuxWineSet(scanCustom)
 
-    if (!existsSync(`${toolsPath}/proton`)) {
-      mkdirSync(`${toolsPath}/proton`, { recursive: true })
-    }
-
-    const altWine = new Set<WineInstallation>()
-
-    readdirSync(`${toolsPath}/wine/`).forEach((version) => {
-      const wineBin = join(toolsPath, 'wine', version, 'bin', 'wine')
-      altWine.add({
-        bin: wineBin,
-        name: `Wine - ${version}`,
-        type: 'wine',
-        ...this.getWineLibs(wineBin),
-        ...this.getWineExecs(wineBin)
-      })
-    })
-
-    const lutrisPath = `${homedir()}/.local/share/lutris`
-    const lutrisCompatPath = `${lutrisPath}/runners/wine/`
-
-    if (existsSync(lutrisCompatPath)) {
-      readdirSync(lutrisCompatPath).forEach((version) => {
-        const wineBin = join(lutrisCompatPath, version, 'bin', 'wine')
-        altWine.add({
-          bin: wineBin,
-          name: `Wine - ${version}`,
-          type: 'wine',
-          ...this.getWineLibs(wineBin),
-          ...this.getWineExecs(wineBin)
-        })
-      })
-    }
-
-    const protonPaths = [`${toolsPath}/proton/`]
-
-    await getSteamLibraries().then((libs) => {
-      libs.forEach((path) => {
-        protonPaths.push(`${path}/steam/steamapps/common`)
-        protonPaths.push(`${path}/steamapps/common`)
-        protonPaths.push(`${path}/root/compatibilitytools.d`)
-        protonPaths.push(`${path}/compatibilitytools.d`)
-        return
-      })
-    })
-
-    const proton = new Set<WineInstallation>()
-
-    protonPaths.forEach((path) => {
-      if (existsSync(path)) {
-        readdirSync(path).forEach((version) => {
-          const protonBin = join(path, version, 'proton')
-          // check if bin exists to avoid false positives
-          if (existsSync(protonBin)) {
-            proton.add({
-              bin: protonBin,
-              name: `Proton - ${version}`,
-              type: 'proton'
-              // No need to run this.getWineExecs here since Proton ships neither Wineboot nor Wineserver
-            })
-          }
-        })
-      }
-    })
-
-    const defaultWineSet = new Set<WineInstallation>()
-    const defaultWine = await this.getDefaultWine()
-    if (!defaultWine.name.includes('Not Found')) {
-      defaultWineSet.add(defaultWine)
-    }
-
-    let customWineSet = new Set<WineInstallation>()
-    if (scanCustom) {
-      customWineSet = this.getCustomWinePaths()
-    }
-
-    return [...defaultWineSet, ...altWine, ...proton, ...customWineSet]
-  }
-
-  /**
-   * Checks if a Wine version has the Wineserver executable and returns the path to it if it's present
-   * @param wineBin The unquoted path to the Wine binary ('wine')
-   * @returns The quoted path to wineserver, if present
-   */
-  public getWineExecs(wineBin: string): { wineserver: string } {
-    const wineDir = dirname(wineBin)
-    const ret = { wineserver: '' }
-    const potWineserverPath = join(wineDir, 'wineserver')
-    if (existsSync(potWineserverPath)) {
-      ret.wineserver = potWineserverPath
-    }
-    return ret
-  }
-
-  /**
-   * Checks if a Wine version has lib/lib32 folders and returns the path to those if they're present
-   * @param wineBin The unquoted path to the Wine binary ('wine')
-   * @returns The paths to lib and lib32, if present
-   */
-  public getWineLibs(wineBin: string): {
-    lib: string
-    lib32: string
-  } {
-    const wineDir = dirname(wineBin)
-    const ret = { lib: '', lib32: '' }
-    const potLib32Path = join(wineDir, '../lib')
-    if (existsSync(potLib32Path)) {
-      ret.lib32 = potLib32Path
-    }
-    const potLibPath = join(wineDir, '../lib64')
-    if (existsSync(potLibPath)) {
-      ret.lib = potLibPath
-    }
-    return ret
+    return [...linuxWineSet]
   }
 
   /**
@@ -448,13 +183,6 @@ abstract class GlobalConfig {
    * @returns true if upgrade successful if upgrade fails or no upgrade needed.
    */
   public abstract upgrade(): boolean
-
-  /**
-   * Get custom Wine installations as defined in the config file.
-   *
-   * @returns Set of Wine installations.
-   */
-  public abstract getCustomWinePaths(): Set<WineInstallation>
 
   /**
    * Get default settings as if the user's config file doesn't exist.
@@ -555,34 +283,10 @@ class GlobalConfigV0 extends GlobalConfig {
     return settings
   }
 
-  public getCustomWinePaths(): Set<WineInstallation> {
-    const customPaths = new Set<WineInstallation>()
-    // skips this on new installations to avoid infinite loops
-    if (existsSync(configPath)) {
-      const { customWinePaths = [] } = this.getSettings()
-      customWinePaths.forEach((path: string) => {
-        if (path.endsWith('proton')) {
-          return customPaths.add({
-            bin: path,
-            name: `Custom Proton - ${path}`,
-            type: 'proton'
-          })
-        }
-        return customPaths.add({
-          bin: path,
-          name: `Custom Wine - ${path}`,
-          type: 'wine',
-          ...this.getWineExecs(path)
-        })
-      })
-    }
-    return customPaths
-  }
-
   public getFactoryDefaults(): AppSettings {
     const account_id = LegendaryUser.getUserInfo()?.account_id
     const userName = user().username
-    const defaultWine = isWindows ? {} : this.getDefaultWine()
+    const defaultWine = isWindows ? {} : getDefaultWine()
 
     // @ts-expect-error TODO: We need to settle on *one* place to define settings defaults
     return {

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -219,20 +219,10 @@ async function prepareWineLaunch(
   // If DXVK/VKD3D installation is enabled, install it
   if (gameSettings.wineVersion.type === 'wine') {
     if (gameSettings.autoInstallDxvk) {
-      await DXVK.installRemove(
-        gameSettings.winePrefix,
-        gameSettings.wineVersion.bin,
-        'dxvk',
-        'backup'
-      )
+      await DXVK.installRemove(gameSettings, 'dxvk', 'backup')
     }
     if (gameSettings.autoInstallVkd3d) {
-      await DXVK.installRemove(
-        gameSettings.winePrefix,
-        gameSettings.wineVersion.bin,
-        'vkd3d',
-        'backup'
-      )
+      await DXVK.installRemove(gameSettings, 'vkd3d', 'backup')
     }
   }
 
@@ -254,6 +244,10 @@ function setupEnvVars(gameSettings: GameSettings) {
     ret.DRI_PRIME = '1'
     ret.__NV_PRIME_RENDER_OFFLOAD = '1'
     ret.__GLX_VENDOR_LIBRARY_NAME = 'nvidia'
+  }
+
+  if (isMac && gameSettings.showFps) {
+    ret.MTL_HUD_ENABLED = '1'
   }
 
   if (gameSettings.enviromentOptions) {
@@ -313,7 +307,7 @@ function setupWineEnvVars(gameSettings: GameSettings, gameId = '0') {
   }
 
   if (gameSettings.showFps) {
-    ret.DXVK_HUD = 'fps'
+    isMac ? (ret.MTL_HUD_ENABLED = '1') : (ret.DXVK_HUD = 'fps')
   }
   if (gameSettings.enableFSR) {
     ret.WINE_FULLSCREEN_FSR = '1'
@@ -509,19 +503,16 @@ function launchCleanup(rpcClient?: RpcClient) {
     logInfo('Stopped Discord Rich Presence', LogPrefix.Backend)
   }
 }
-async function runWineCommand(
-  {
-    gameSettings,
-    commandParts,
-    wait,
-    protonVerb = 'run',
-    installFolderName,
-    options,
-    startFolder,
-    skipPrefixCheckIKnowWhatImDoing = false
-  }: WineCommandArgs,
-  gameInfo?: GameInfo
-): Promise<{ stderr: string; stdout: string }> {
+async function runWineCommand({
+  gameSettings,
+  commandParts,
+  wait,
+  protonVerb = 'run',
+  installFolderName,
+  options,
+  startFolder,
+  skipPrefixCheckIKnowWhatImDoing = false
+}: WineCommandArgs): Promise<{ stderr: string; stdout: string }> {
   const settings = gameSettings
     ? gameSettings
     : GlobalConfig.get().getSettings()
@@ -595,9 +586,6 @@ async function runWineCommand(
     child.stdout.setEncoding('utf-8')
     child.stderr.setEncoding('utf-8')
 
-    if (gameInfo && gameInfo.runner === 'hyperplay')
-      openOverlay(gameInfo.app_name, gameInfo.runner)
-
     if (options?.logFile) {
       logDebug(`Logging to file "${options?.logFile}"`, LogPrefix.Backend)
     }
@@ -638,7 +626,6 @@ async function runWineCommand(
     })
 
     child.on('close', async () => {
-      if (gameInfo && gameInfo.runner === 'hyperplay') closeOverlay()
       const response = { stderr: stderr.join(''), stdout: stdout.join('') }
 
       if (wait && wineVersion.wineserver) {
@@ -658,7 +645,6 @@ async function runWineCommand(
     })
 
     child.on('error', (error) => {
-      if (gameInfo && gameInfo.runner === 'hyperplay') closeOverlay()
       console.log(error)
     })
   })

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -280,7 +280,8 @@ function setupWineEnvVars(gameSettings: GameSettings, gameId = '0') {
   // Add WINEPREFIX / STEAM_COMPAT_DATA_PATH / CX_BOTTLE
   const steamInstallPath = join(flatPakHome, '.steam', 'steam')
   switch (wineVersion.type) {
-    case 'wine': {
+    case 'wine':
+    case 'toolkit': {
       ret.WINEPREFIX = winePrefix
 
       // Disable Winemenubuilder to not mess with file associations
@@ -594,7 +595,9 @@ async function runWineCommand({
       writeFileSync(options.logFile, '')
       appendFileSync(
         options.logFile,
-        `Wine Command: ${bin} ${commandParts.join(' ')}\n\nGame Log:\n`
+        `Wine Command: WINEPREFIX=${winePrefix} ${bin} ${commandParts.join(
+          ' '
+        )}\n\nGame Log:\n`
       )
     }
 

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -308,7 +308,13 @@ function setupWineEnvVars(gameSettings: GameSettings, gameId = '0') {
   }
 
   if (gameSettings.showFps) {
-    isMac ? (ret.MTL_HUD_ENABLED = '1') : (ret.DXVK_HUD = 'fps')
+    // If the operating system is macOS, enable the Metal HUD
+    // Otherwise, enable the DXVK FPS HUD
+    if (isMac) {
+      ret.MTL_HUD_ENABLED = '1'
+    } else {
+      ret.DXVK_HUD = 'fps'
+    }
   }
   if (gameSettings.enableFSR) {
     ret.WINE_FULLSCREEN_FSR = '1'

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -938,12 +938,20 @@ ipcMain.handle('requestSettings', async (event, appName) => {
   return mapOtherSettings(config)
 })
 
-ipcMain.handle('toggleDXVK', async (event, { winePrefix, winePath, action }) =>
-  DXVK.installRemove(winePrefix, winePath, 'dxvk', action)
+ipcMain.handle('toggleDXVK', async (event, { appName, action }) =>
+  GameConfig.get(appName)
+    .getSettings()
+    .then(async (gameSettings) =>
+      DXVK.installRemove(gameSettings, 'dxvk', action)
+    )
 )
 
-ipcMain.on('toggleVKD3D', (event, { winePrefix, winePath, action }) => {
-  DXVK.installRemove(winePrefix, winePath, 'vkd3d', action)
+ipcMain.on('toggleVKD3D', (event, { appName, action }) => {
+  GameConfig.get(appName)
+    .getSettings()
+    .then((gameSettings) => {
+      DXVK.installRemove(gameSettings, 'vkd3d', action)
+    })
 })
 
 ipcMain.handle('writeConfig', (event, { appName, config }) => {

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -63,6 +63,7 @@ import { showDialogBoxModalAuto } from '../../dialog/dialog'
 import { sendFrontendMessage } from '../../main_window'
 import { RemoveArgs } from 'common/types/game_manager'
 import { logFileLocation } from 'backend/storeManagers/storeManagerCommon/games'
+import { getWineFlags } from 'backend/utils/compatibility_layers'
 
 export async function getExtraInfo(appName: string): Promise<ExtraInfo> {
   const gameInfo = getGameInfo(appName)
@@ -434,7 +435,7 @@ export async function launch(
   let commandEnv = isWindows
     ? process.env
     : { ...process.env, ...setupEnvVars(gameSettings) }
-  const wineFlag: string[] = []
+  let wineFlag: string[] = []
 
   if (!isNative(appName)) {
     const {
@@ -470,11 +471,7 @@ export async function launch(
         ? wineExec.replaceAll("'", '')
         : wineExec
 
-    wineFlag.push(
-      ...(wineType === 'proton'
-        ? ['--no-wine', '--wrapper', `'${wineBin}' run`]
-        : ['--wine', wineBin])
-    )
+    wineFlag = [...getWineFlags(wineBin, gameSettings, wineType)]
   }
 
   const commandParts = [

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -66,6 +66,7 @@ import { Catalog, Product } from 'common/types/epic-graphql'
 import { sendFrontendMessage } from '../../main_window'
 import { RemoveArgs } from 'common/types/game_manager'
 import { logFileLocation } from 'backend/storeManagers/storeManagerCommon/games'
+import { getWineFlags } from 'backend/utils/compatibility_layers'
 
 /**
  * Alias for `LegendaryLibrary.listUpdateableGames`
@@ -813,7 +814,7 @@ export async function launch(
   let commandEnv = isWindows
     ? process.env
     : { ...process.env, ...setupEnvVars(gameSettings) }
-  const wineFlag: string[] = []
+  let wineFlag: string[] = []
   if (!isNative(appName)) {
     // -> We're using Wine/Proton on Linux or CX on Mac
     const {
@@ -849,11 +850,7 @@ export async function launch(
         ? wineExec.replaceAll("'", '')
         : wineExec
 
-    wineFlag.push(
-      ...(wineType === 'proton'
-        ? ['--no-wine', '--wrapper', `'${wineBin}' run`]
-        : ['--wine', wineBin])
-    )
+    wineFlag = [...getWineFlags(wineBin, gameSettings, wineType)]
   }
 
   // Log any launch information configured in Legendary's config.ini

--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -346,20 +346,17 @@ export async function launchGame(
       LogPrefix.Backend
     )
 
-    await runWineCommand(
-      {
-        commandParts: [executable, launcherArgs ?? ''],
-        gameSettings,
-        wait: false,
-        startFolder: dirname(executable),
-        options: {
-          wrappers,
-          logFile: logFileLocation(appName),
-          logMessagePrefix: LogPrefix.Backend
-        }
-      },
-      gameInfo
-    )
+    await runWineCommand({
+      commandParts: [executable, launcherArgs ?? ''],
+      gameSettings,
+      wait: false,
+      startFolder: dirname(executable),
+      options: {
+        wrappers,
+        logFile: logFileLocation(appName),
+        logMessagePrefix: LogPrefix.Backend
+      }
+    })
 
     launchCleanup(rpcClient)
 

--- a/src/backend/tools.ts
+++ b/src/backend/tools.ts
@@ -1,4 +1,4 @@
-import { WineInstallation } from 'common/types'
+import { GameSettings, WineInstallation } from 'common/types'
 import axios from 'axios'
 import {
   existsSync,
@@ -130,11 +130,20 @@ export const DXVK = {
   },
 
   installRemove: async (
-    prefix: string,
-    winePath: string,
+    gameSettings: GameSettings,
     tool: 'dxvk' | 'vkd3d' | 'dxvk-macOS',
     action: 'backup' | 'restore'
   ): Promise<boolean> => {
+    if (gameSettings.wineVersion.bin.includes('toolkit')) {
+      // we don't want to install dxvk on the toolkit prefix since it breaks Apple's implementation
+      logWarning(
+        'Skipping DXVK install on Game Porting Toolkit prefix!',
+        LogPrefix.DXVKInstaller
+      )
+      return true
+    }
+
+    const prefix = gameSettings.winePrefix
     const winePrefix = prefix.replace('~', userHome)
     const isValidPrefix = existsSync(`${winePrefix}/.update-timestamp`)
 
@@ -150,7 +159,7 @@ export const DXVK = {
     tool = isMac ? 'dxvk-macOS' : tool
 
     // remove the last part of the path since we need the folder only
-    const wineBin = winePath.replace("'", '')
+    const wineBin = gameSettings.wineVersion.bin
 
     if (!existsSync(`${toolsPath}/${tool}/latest_${tool}`)) {
       logWarning('dxvk not found!', LogPrefix.DXVKInstaller)

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -369,6 +369,8 @@ async function errorHandler({
   const plat = r === 'legendary' ? 'Legendary (Epic Games)' : r
   const deletedFolderMsg = 'appears to be deleted'
   const otherErrorMessages = ['No saved credentials', 'No credentials']
+  // this message appears on macOS when no Crossover was found in the system but its a false alarm
+  const ignoreCrossoverMessage = 'IndexError: list index out of range'
 
   if (logPath) {
     execAsync(`tail "${logPath}" | grep 'disk space'`)
@@ -391,6 +393,9 @@ async function errorHandler({
       })
   }
   if (error) {
+    if (error.includes(ignoreCrossoverMessage)) {
+      return
+    }
     if (error.includes(deletedFolderMsg) && appName) {
       const runner = r.toLocaleLowerCase() as Runner
       const { title } = gameManagerMap[runner].getGameInfo(appName)

--- a/src/backend/utils/__tests__/compatibility_layers.test.ts
+++ b/src/backend/utils/__tests__/compatibility_layers.test.ts
@@ -1,4 +1,3 @@
-import { describe } from 'node:test'
 import {
   getDefaultWine,
   getWineExecs,
@@ -32,7 +31,7 @@ describe('getDefaultWine', () => {
     // spy on the execSync calling which wine and returning /usr/bin/wine
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const execSync = jest.spyOn(require('child_process'), 'execSync')
-    execSync.mockImplementation((command: any) => {
+    execSync.mockImplementation((command: unknown) => {
       if (command === 'which wine') {
         return '/usr/bin/wine\n'
       } else if (command === 'wine --version') {

--- a/src/backend/utils/__tests__/compatibility_layers.test.ts
+++ b/src/backend/utils/__tests__/compatibility_layers.test.ts
@@ -1,0 +1,105 @@
+import { describe } from 'node:test'
+import {
+  getDefaultWine,
+  getWineExecs,
+  getWineLibs
+} from '../compatibility_layers'
+import { mkdirSync } from 'graceful-fs'
+import { dirname, join } from 'path'
+import { tmpdir } from 'os'
+
+jest.mock('../../logger/logfile')
+
+describe('getDefaultWine', () => {
+  test('return wine not found', () => {
+    const expected = {
+      bin: '',
+      name: 'Default Wine - Not Found',
+      type: 'wine'
+    }
+    const result = getDefaultWine()
+    expect(result).toEqual(expected)
+  })
+
+  test('return list with one default wine', () => {
+    const expected = {
+      bin: '/usr/bin/wine',
+      name: 'Wine Default - wine-6.0 (Staging)',
+      type: 'wine',
+      wineserver: ''
+    }
+
+    // spy on the execSync calling which wine and returning /usr/bin/wine
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const execSync = jest.spyOn(require('child_process'), 'execSync')
+    execSync.mockImplementation((command: any) => {
+      if (command === 'which wine') {
+        return '/usr/bin/wine\n'
+      } else if (command === 'wine --version') {
+        return 'wine-6.0 (Staging)\n'
+      }
+      throw new Error('Unexpected command')
+    })
+
+    const result = getDefaultWine()
+    expect(result).toEqual(expected)
+  })
+})
+
+describe('getWineLibs', () => {
+  it('should return empty strings if lib and lib32 do not exist', () => {
+    const wineBin = '/path/to/wine'
+    const { lib, lib32 } = getWineLibs(wineBin)
+    expect(lib).toBe('')
+    expect(lib32).toBe('')
+  })
+
+  it('should return the path to lib32 if it exists', () => {
+    const wineBin = join(tmpdir(), 'wine_test')
+    const wineDir = join(wineBin, '..')
+    const lib32Path = join(wineDir, '../lib')
+    mkdirSync(lib32Path, { recursive: true })
+    const { lib32 } = getWineLibs(wineBin)
+    expect(lib32).toBe(lib32Path)
+  })
+
+  it('should return the path to lib if it exists', () => {
+    const wineBin = join(tmpdir(), 'wine_test')
+    const wineDir = join(wineBin, '..')
+    const libPath = join(wineDir, '../lib64')
+    mkdirSync(libPath, { recursive: true })
+    const { lib } = getWineLibs(wineBin)
+    expect(lib).toBe(libPath)
+  })
+
+  it('should return the paths to lib and lib32 if they both exist', () => {
+    const wineBin = join(tmpdir(), 'wine_test')
+    const wineDir = join(wineBin, '..')
+    const libPath = join(wineDir, '../lib64')
+    const lib32Path = join(wineDir, '../lib')
+    mkdirSync(libPath, { recursive: true })
+    mkdirSync(lib32Path, { recursive: true })
+    const { lib, lib32 } = getWineLibs(wineBin)
+    expect(lib).toBe(libPath)
+    expect(lib32).toBe(lib32Path)
+  })
+})
+
+describe('getWineExes', () => {
+  describe('getWineExecs', () => {
+    it('should return the path to wineserver if it exists', () => {
+      const wineBin = join(tmpdir(), 'wine_test')
+      const wineDir = dirname(wineBin)
+      const wineServerPath = join(wineDir, 'wineserver')
+      mkdirSync(wineServerPath, { recursive: true })
+      const execs = getWineExecs(wineBin)
+      expect(execs.wineserver).toBe(wineServerPath)
+    })
+
+    it('should return an empty string if wineserver does not exist', () => {
+      const wineBin = '/path/to/wine'
+      const execs = getWineExecs(wineBin)
+      expect(execs.wineserver).toBe('')
+    })
+  })
+})

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -1,0 +1,389 @@
+import { GlobalConfig } from 'backend/config'
+import {
+  configPath,
+  getSteamLibraries,
+  isMac,
+  toolsPath,
+  userHome
+} from 'backend/constants'
+import { logError, LogPrefix, logInfo } from 'backend/logger/logger'
+import { execAsync } from 'backend/utils'
+import { execSync } from 'child_process'
+import { GameSettings, WineInstallation } from 'common/types'
+import { existsSync, mkdirSync, readFileSync, readdirSync } from 'graceful-fs'
+import { homedir } from 'os'
+import { dirname, join } from 'path'
+import { PlistObject, parse as plistParse } from 'plist'
+
+/**
+ * Loads the default wine installation path and version.
+ *
+ * @returns Promise<WineInstallation>
+ */
+export function getDefaultWine(): WineInstallation {
+  const defaultWine: WineInstallation = {
+    bin: '',
+    name: 'Default Wine - Not Found',
+    type: 'wine'
+  }
+
+  try {
+    let stdout = execSync(`which wine`).toString()
+    const wineBin = stdout.split('\n')[0]
+    defaultWine.bin = wineBin
+
+    stdout = execSync(`wine --version`).toString()
+    const version = stdout.split('\n')[0]
+    defaultWine.name = `Wine Default - ${version}`
+
+    return {
+      ...defaultWine,
+      ...getWineExecs(wineBin)
+    }
+  } catch {
+    return defaultWine
+  }
+}
+
+function getCustomWinePaths(): Set<WineInstallation> {
+  const customPaths = new Set<WineInstallation>()
+  // skips this on new installations to avoid infinite loops
+  if (existsSync(configPath)) {
+    const { customWinePaths = [] } = GlobalConfig.get().getSettings()
+    customWinePaths.forEach((path: string) => {
+      if (path.endsWith('proton')) {
+        return customPaths.add({
+          bin: path,
+          name: `Custom Proton - ${path}`,
+          type: 'proton'
+        })
+      }
+      return customPaths.add({
+        bin: path,
+        name: `Custom Wine - ${path}`,
+        type: 'wine',
+        ...getWineExecs(path)
+      })
+    })
+  }
+  return customPaths
+}
+
+/**
+ * Checks if a Wine version has the Wineserver executable and returns the path to it if it's present
+ * @param wineBin The unquoted path to the Wine binary ('wine')
+ * @returns The quoted path to wineserver, if present
+ */
+export function getWineExecs(wineBin: string): { wineserver: string } {
+  const wineDir = dirname(wineBin)
+  const ret = { wineserver: '' }
+  const potWineserverPath = join(wineDir, 'wineserver')
+  if (existsSync(potWineserverPath)) {
+    ret.wineserver = potWineserverPath
+  }
+  return ret
+}
+
+/**
+ * Checks if a Wine version has lib/lib32 folders and returns the path to those if they're present
+ * @param wineBin The unquoted path to the Wine binary ('wine')
+ * @returns The paths to lib and lib32, if present
+ */
+export function getWineLibs(wineBin: string): {
+  lib: string
+  lib32: string
+} {
+  const wineDir = dirname(wineBin)
+  const ret = { lib: '', lib32: '' }
+  const potLib32Path = join(wineDir, '../lib')
+  if (existsSync(potLib32Path)) {
+    ret.lib32 = potLib32Path
+  }
+  const potLibPath = join(wineDir, '../lib64')
+  if (existsSync(potLibPath)) {
+    ret.lib = potLibPath
+  }
+  return ret
+}
+
+export async function getLinuxWineSet(
+  scanCustom?: boolean
+): Promise<Set<WineInstallation>> {
+  if (!existsSync(`${toolsPath}/wine`)) {
+    mkdirSync(`${toolsPath}/wine`, { recursive: true })
+  }
+
+  if (!existsSync(`${toolsPath}/proton`)) {
+    mkdirSync(`${toolsPath}/proton`, { recursive: true })
+  }
+
+  const altWine = new Set<WineInstallation>()
+
+  readdirSync(`${toolsPath}/wine/`).forEach((version) => {
+    const wineBin = join(toolsPath, 'wine', version, 'bin', 'wine')
+    altWine.add({
+      bin: wineBin,
+      name: `Wine - ${version}`,
+      type: 'wine',
+      ...getWineLibs(wineBin),
+      ...getWineExecs(wineBin)
+    })
+  })
+
+  const lutrisPath = `${homedir()}/.local/share/lutris`
+  const lutrisCompatPath = `${lutrisPath}/runners/wine/`
+
+  if (existsSync(lutrisCompatPath)) {
+    readdirSync(lutrisCompatPath).forEach((version) => {
+      const wineBin = join(lutrisCompatPath, version, 'bin', 'wine')
+      altWine.add({
+        bin: wineBin,
+        name: `Wine - ${version}`,
+        type: 'wine',
+        ...getWineLibs(wineBin),
+        ...getWineExecs(wineBin)
+      })
+    })
+  }
+
+  const protonPaths = [`${toolsPath}/proton/`]
+
+  await getSteamLibraries().then((libs) => {
+    libs.forEach((path) => {
+      protonPaths.push(`${path}/steam/steamapps/common`)
+      protonPaths.push(`${path}/steamapps/common`)
+      protonPaths.push(`${path}/root/compatibilitytools.d`)
+      protonPaths.push(`${path}/compatibilitytools.d`)
+      return
+    })
+  })
+
+  const proton = new Set<WineInstallation>()
+
+  protonPaths.forEach((path) => {
+    if (existsSync(path)) {
+      readdirSync(path).forEach((version) => {
+        const protonBin = join(path, version, 'proton')
+        // check if bin exists to avoid false positives
+        if (existsSync(protonBin)) {
+          proton.add({
+            bin: protonBin,
+            name: `Proton - ${version}`,
+            type: 'proton'
+            // No need to run this.getWineExecs here since Proton ships neither Wineboot nor Wineserver
+          })
+        }
+      })
+    }
+  })
+
+  const defaultWineSet = new Set<WineInstallation>()
+  const defaultWine = await getDefaultWine()
+  if (!defaultWine.name.includes('Not Found')) {
+    defaultWineSet.add(defaultWine)
+  }
+
+  let customWineSet = new Set<WineInstallation>()
+  if (scanCustom) {
+    customWineSet = getCustomWinePaths()
+  }
+
+  return new Set([...defaultWineSet, ...altWine, ...proton, ...customWineSet])
+}
+
+/// --------------- MACOS ------------------
+
+/**
+ * Detects Wine installed on home application folder on Mac
+ *
+ * @returns Promise<Set<WineInstallation>>
+ */
+export async function getWineOnMac(): Promise<Set<WineInstallation>> {
+  const wineSet = new Set<WineInstallation>()
+  if (!isMac) {
+    return wineSet
+  }
+
+  const winePaths = new Set<string>()
+
+  // search for wine installed on $HOME/Library/Application Support/heroic/tools/wine
+  const wineToolsPath = `${toolsPath}/wine/`
+  if (existsSync(wineToolsPath)) {
+    readdirSync(wineToolsPath).forEach((path) => {
+      winePaths.add(join(wineToolsPath, path))
+    })
+  }
+
+  // search for wine installed around the system
+  await execAsync('mdfind kMDItemCFBundleIdentifier = "*.wine"').then(
+    async ({ stdout }) => {
+      stdout.split('\n').forEach((winePath) => {
+        winePaths.add(winePath)
+      })
+    }
+  )
+
+  winePaths.forEach((winePath) => {
+    const infoFilePath = join(winePath, 'Contents/Info.plist')
+    if (winePath && existsSync(infoFilePath)) {
+      const info = plistParse(
+        readFileSync(infoFilePath, 'utf-8')
+      ) as PlistObject
+      const version = info['CFBundleShortVersionString'] || ''
+      const name = info['CFBundleName'] || ''
+      const wineBin = join(winePath, '/Contents/Resources/wine/bin/wine64')
+      if (existsSync(wineBin)) {
+        wineSet.add({
+          ...getWineExecs(wineBin),
+          lib: `${winePath}/Contents/Resources/wine/lib`,
+          lib32: `${winePath}/Contents/Resources/wine/lib`,
+          bin: wineBin,
+          name: `${name} - ${version}`,
+          type: 'wine',
+          ...getWineExecs(wineBin)
+        })
+      }
+    }
+  })
+
+  return wineSet
+}
+
+export async function getWineskinWine(): Promise<Set<WineInstallation>> {
+  const wineSet = new Set<WineInstallation>()
+  if (!isMac) {
+    return wineSet
+  }
+  const wineSkinPath = `${userHome}/Applications/Wineskin`
+  if (existsSync(wineSkinPath)) {
+    const apps = readdirSync(wineSkinPath)
+    for (const app of apps) {
+      if (app.includes('.app')) {
+        const wineBin = `${userHome}/Applications/Wineskin/${app}/Contents/SharedSupport/wine/bin/wine64`
+        if (existsSync(wineBin)) {
+          try {
+            const { stdout: out } = await execAsync(`'${wineBin}' --version`)
+            const version = out.split('\n')[0]
+            wineSet.add({
+              ...getWineExecs(wineBin),
+              lib: `${userHome}/Applications/Wineskin/${app}/Contents/SharedSupport/wine/lib`,
+              lib32: `${userHome}/Applications/Wineskin/${app}/Contents/SharedSupport/wine/lib`,
+              name: `Wineskin - ${version}`,
+              type: 'wine',
+              bin: wineBin
+            })
+          } catch (error) {
+            logError(
+              `Error getting wine version for ${wineBin}`,
+              LogPrefix.GlobalConfig
+            )
+          }
+        }
+      }
+    }
+  }
+  return wineSet
+}
+
+/**
+ * Detects CrossOver installs on Mac
+ *
+ * @returns Promise<Set<WineInstallation>>
+ */
+export async function getCrossover(): Promise<Set<WineInstallation>> {
+  const crossover = new Set<WineInstallation>()
+
+  if (!isMac) {
+    return crossover
+  }
+
+  await execAsync(
+    'mdfind kMDItemCFBundleIdentifier = "com.codeweavers.CrossOver"'
+  )
+    .then(async ({ stdout }) => {
+      stdout.split('\n').forEach((crossoverMacPath) => {
+        const infoFilePath = join(crossoverMacPath, 'Contents/Info.plist')
+        if (crossoverMacPath && existsSync(infoFilePath)) {
+          const info = plistParse(
+            readFileSync(infoFilePath, 'utf-8')
+          ) as PlistObject
+          const version = info['CFBundleShortVersionString'] || ''
+          const crossoverWineBin = join(
+            crossoverMacPath,
+            'Contents/SharedSupport/CrossOver/bin/wine'
+          )
+          crossover.add({
+            bin: crossoverWineBin,
+            name: `CrossOver - ${version}`,
+            type: 'crossover',
+            ...getWineExecs(crossoverWineBin)
+          })
+        }
+      })
+    })
+    .catch(() => {
+      logInfo('CrossOver not found', LogPrefix.GlobalConfig)
+    })
+  return crossover
+}
+
+/**
+ * Detects Gaming Porting Toolkit Wine installs on Mac
+ * @returns Promise<Set<WineInstallation>>
+ **/
+export async function getGamingPortingToolkitWine(): Promise<
+  Set<WineInstallation>
+> {
+  const gamingPortingToolkitWine = new Set<WineInstallation>()
+  if (!isMac) {
+    return gamingPortingToolkitWine
+  }
+
+  logInfo('Searching for Gaming Porting Toolkit Wine', LogPrefix.GlobalConfig)
+  const { stdout } = await execAsync('mdfind wine64')
+  const wineBin = stdout.split('\n').filter((p) => {
+    return p.match(/game-porting-toolkit.*\/wine64$/)
+  })[0]
+
+  if (existsSync(wineBin)) {
+    logInfo(
+      `Found Gaming Porting Toolkit Wine at ${dirname(wineBin)}`,
+      LogPrefix.GlobalConfig
+    )
+    try {
+      const { stdout: out } = await execAsync(`'${wineBin}' --version`)
+      const version = out.split('\n')[0]
+      gamingPortingToolkitWine.add({
+        ...getWineExecs(wineBin),
+        name: `GPTK Wine (DX11/DX12 Only) - ${version}`,
+        type: 'toolkit',
+        lib: `${dirname(wineBin)}/../lib`,
+        lib32: `${dirname(wineBin)}/../lib`,
+        bin: wineBin
+      })
+    } catch (error) {
+      logError(
+        `Error getting wine version for ${wineBin}`,
+        LogPrefix.GlobalConfig
+      )
+    }
+  }
+
+  return gamingPortingToolkitWine
+}
+
+export function getWineFlags(
+  wineBin: string,
+  gameSettings: GameSettings,
+  wineType: string
+) {
+  const wineFlags = []
+  const wineFlagsObj = {
+    proton: ['--no-wine', '--wrapper', `'${wineBin}' run`],
+    wine: ['--wine', wineBin],
+    toolkit: ['--wrapper', `${wineBin} ${gameSettings.winePrefix}`, '--no-wine']
+  }
+
+  wineFlags.push(...(wineFlagsObj[wineType as keyof typeof wineFlagsObj] || []))
+  return wineFlags
+}

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -283,7 +283,7 @@ export type UserInfo = {
 export interface WineInstallation {
   bin: string
   name: string
-  type: 'wine' | 'proton' | 'crossover'
+  type: 'wine' | 'proton' | 'crossover' | 'toolkit'
   lib?: string
   lib32?: string
   wineserver?: string

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -625,6 +625,7 @@ export type WineCommandArgs = {
   installFolderName?: string
   options?: CallRunnerOptions
   startFolder?: string
+  gameInstallPath?: string
   skipPrefixCheckIKnowWhatImDoing?: boolean
 }
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -667,8 +667,7 @@ export interface DiskSpaceData {
 }
 
 export interface ToolArgs {
-  winePrefix: string
-  winePath: string
+  appName: string
   action: 'backup' | 'restore'
 }
 

--- a/src/frontend/screens/Settings/components/AutoDXVK.tsx
+++ b/src/frontend/screens/Settings/components/AutoDXVK.tsx
@@ -18,7 +18,7 @@ const AutoDXVK = () => {
   const [wineVersion] = useSetting('wineVersion', defaultWineVersion)
   const [installingDxvk, setInstallingDxvk] = React.useState(false)
 
-  if (wineVersion.type !== 'wine') {
+  if (wineVersion.type !== 'wine' || wineVersion.bin.includes('toolkit')) {
     return <></>
   }
 

--- a/src/frontend/screens/Settings/components/AutoDXVK.tsx
+++ b/src/frontend/screens/Settings/components/AutoDXVK.tsx
@@ -1,11 +1,11 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
 import { defaultWineVersion } from '..'
 import useSetting from 'frontend/hooks/useSetting'
-import { configStore } from 'frontend/helpers/electronStores'
 import { ToggleSwitch } from 'frontend/components/UI'
+import SettingsContext from '../SettingsContext'
 
 const AutoDXVK = () => {
   const { t } = useTranslation()
@@ -13,10 +13,9 @@ const AutoDXVK = () => {
     'autoInstallDxvk',
     false
   )
-  const home = configStore.get('userHome', '')
-  const [winePrefix] = useSetting('winePrefix', `${home}/.wine`)
   const [wineVersion] = useSetting('wineVersion', defaultWineVersion)
   const [installingDxvk, setInstallingDxvk] = React.useState(false)
+  const { appName } = useContext(SettingsContext)
 
   if (wineVersion.type !== 'wine' || wineVersion.bin.includes('toolkit')) {
     return <></>
@@ -26,8 +25,7 @@ const AutoDXVK = () => {
     const action = autoInstallDxvk ? 'restore' : 'backup'
     setInstallingDxvk(true)
     const res = await window.api.toggleDXVK({
-      winePrefix,
-      winePath: wineVersion.bin,
+      appName,
       action
     })
 

--- a/src/frontend/screens/Settings/components/AutoVKD3D.tsx
+++ b/src/frontend/screens/Settings/components/AutoVKD3D.tsx
@@ -1,11 +1,11 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ToggleSwitch } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
-import { configStore } from 'frontend/helpers/electronStores'
 import { defaultWineVersion } from '..'
+import SettingsContext from '../SettingsContext'
 
 const AutoVKD3D = () => {
   const { t } = useTranslation()
@@ -13,9 +13,8 @@ const AutoVKD3D = () => {
     'autoInstallVkd3d',
     false
   )
-  const home = configStore.get('userHome', '')
-  const [winePrefix] = useSetting('winePrefix', `${home}/.wine`)
   const [wineVersion] = useSetting('wineVersion', defaultWineVersion)
+  const { appName } = useContext(SettingsContext)
 
   const isProton = wineVersion.type === 'proton'
 
@@ -25,7 +24,7 @@ const AutoVKD3D = () => {
 
   const handleAutoInstallVkd3d = () => {
     const action = autoInstallVkd3d ? 'restore' : 'backup'
-    window.api.toggleVKD3D({ winePrefix, winePath: wineVersion.bin, action })
+    window.api.toggleVKD3D({ appName, action })
     return setAutoInstallVkd3d(!autoInstallVkd3d)
   }
 

--- a/src/frontend/screens/Settings/components/EnableDXVKFpsLimit.tsx
+++ b/src/frontend/screens/Settings/components/EnableDXVKFpsLimit.tsx
@@ -1,0 +1,64 @@
+import React, { useContext } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ToggleSwitch, TextInputField } from 'frontend/components/UI'
+import useSetting from 'frontend/hooks/useSetting'
+import ContextProvider from 'frontend/state/ContextProvider'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
+import SettingsContext from '../SettingsContext'
+import { defaultWineVersion } from '..'
+
+const EnableDXVKFpsLimit = () => {
+  const { t } = useTranslation()
+  const { platform } = useContext(ContextProvider)
+  const { isLinuxNative, isMacNative } = useContext(SettingsContext)
+  const isWin = platform === 'win32'
+  const [enableDXVKFpsLimit, setDXVKFpsLimit] = useSetting(
+    'enableDXVKFpsLimit',
+    false
+  )
+  const [DXVKFpsCap, setDXVKFpsCap] = useSetting('DXVKFpsCap', '')
+  const [wineVersion] = useSetting('wineVersion', defaultWineVersion)
+
+  if (
+    isWin ||
+    isLinuxNative ||
+    isMacNative ||
+    wineVersion.bin.includes('toolkit')
+  ) {
+    return <></>
+  }
+
+  return (
+    <>
+      <div className="toggleRow">
+        <ToggleSwitch
+          htmlId="enableDXVKFpsLimit"
+          value={enableDXVKFpsLimit || false}
+          handleChange={() => setDXVKFpsLimit(!enableDXVKFpsLimit)}
+          title={t('setting.dxvkfpslimit', 'Limit FPS (DX9, 10 and 11)')}
+        />
+
+        <FontAwesomeIcon
+          className="helpIcon"
+          icon={faCircleInfo}
+          title={t('help.dxvkfpslimit', 'Sets a frame rate cap for DXVK games')}
+        />
+      </div>
+
+      {enableDXVKFpsLimit && (
+        <TextInputField
+          htmlId="DXVKFpsLimitValue"
+          placeholder={t(
+            'placeholder.dxvkfpsvalue',
+            'Positive integer value (e.g. 30, 60, ...)'
+          )}
+          value={DXVKFpsCap}
+          onChange={(event) => setDXVKFpsCap(event.target.value)}
+        />
+      )}
+    </>
+  )
+}
+
+export default EnableDXVKFpsLimit

--- a/src/frontend/screens/Settings/components/ShowFPS.tsx
+++ b/src/frontend/screens/Settings/components/ShowFPS.tsx
@@ -9,9 +9,10 @@ const ShowFPS = () => {
   const { t } = useTranslation()
   const [showFps, setShowFps] = useSetting('showFps', false)
   const { platform } = useContext(ContextProvider)
-  const { isMacNative, isLinuxNative } = useContext(SettingsContext)
+  const { isLinuxNative } = useContext(SettingsContext)
   const isWin = platform === 'win32'
-  const shouldRenderFpsOption = !isMacNative && !isWin && !isLinuxNative
+  const isLinux = platform === 'linux'
+  const shouldRenderFpsOption = !isWin || (isLinux && !isLinuxNative)
 
   if (!shouldRenderFpsOption) {
     return <></>
@@ -22,7 +23,11 @@ const ShowFPS = () => {
       htmlId="showFPS"
       value={showFps}
       handleChange={() => setShowFps(!showFps)}
-      title={t('setting.showfps')}
+      title={
+        isLinux
+          ? t('setting.showfps')
+          : t('setting.showMetalOverlay', 'Show Stats Overlay')
+      }
     />
   )
 }

--- a/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
@@ -37,6 +37,7 @@ import useSetting from 'frontend/hooks/useSetting'
 import { defaultWineVersion } from '../..'
 import Collapsible from 'frontend/components/UI/Collapsible/Collapsible'
 import SyncSaves from '../SyncSaves'
+import EnableDXVKFpsLimit from '../../components/EnableDXVKFpsLimit'
 
 type Props = {
   useDetails?: boolean
@@ -48,6 +49,7 @@ export default function GamesSettings({ useDetails = true }: Props) {
   const { isDefault, gameInfo } = useContext(SettingsContext)
   const [wineVersion] = useSetting('wineVersion', defaultWineVersion)
   const isLinux = platform === 'linux'
+  const isWin = platform === 'win32'
   const isCrossover = wineVersion?.type === 'crossover'
   const hasCloudSaves =
     gameInfo?.cloud_save_enabled && gameInfo.install.platform !== 'linux'
@@ -120,17 +122,19 @@ export default function GamesSettings({ useDetails = true }: Props) {
       >
         <AlternativeExe />
 
-        {!nativeGame && <ShowFPS />}
+        <ShowFPS />
 
-        {isLinux && !nativeGame && (
+        {!nativeGame && <EnableDXVKFpsLimit />}
+
+        {!isWin && !nativeGame && (
           <>
-            <PreferSystemLibs />
-
             <EnableEsync />
 
             {isLinux && (
               <>
                 <EnableFsync />
+
+                <PreferSystemLibs />
 
                 <EnableFSR />
 


### PR DESCRIPTION
With this, Hyperplay will look for a current setup of the apple's GPTK and list it under the Wine List


## HOW TO TEST: Downloaded Games

- To download the build to test, go bellow under 'CHECKS' and build_macOS click on `details`. Then on the page that will open, click on SUMMARY. And then go to ARTIFACTS and download the build for your system.
- Since this build is NOT signed (only releases are), you need to first run this command on the terminal: `xattr -d -r com.apple.quarantine PATH_TO/HyperPlay.app`
- Make sure you have installed the gaming porting toolkit following the Install instructions provided by Apple.
- Make sure Spotlight is enabled and the command `mdfind wine64` returns something on the terminal.
- Try to run some games and make sure it is working already.
- When opening HyperPlay, go to Settings and on Game default check if, under WINE, it shows the GPTK option on the list

- Download and install some Windows games and select the Script you want to use on the game wine settings.
- Use new prefixes instead of reusing an existing one. If you have DXVK installed on the prefix, the game might not work.

## Sideloaded Games

- Tested only Steam so far
- Click on ADD GAMES on the library.
- Fill in the title as you want.
- Select the Gaming Toolkit script you want to use.
- Click on RUN INSTALLER FIRST and select the exe you want to install
- The app will be installed inside the prefix
- On Select EXE, select the exe to run the app, for instance: `/Users/name/Games/GPT_PREFIX/drive_c/Program Files (x86)/Steam/Steam.exe`
- Click Finish

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
