### PR TITLE
[Metrics] Ensure unique metrics id on launch

### DIFF
--- a/src/backend/metrics/metrics.ts
+++ b/src/backend/metrics/metrics.ts
@@ -189,7 +189,9 @@ export const trackScreen = async (name: string, properties?: apiObject) => {
 function ensureUniqueMetricsId() {
   const currentId = metricsStore.get('metricsId')
   const status = metricsStore.get('metricsOptInStatus')
-  if (currentId === ANONYMOUS_ID && status === MetricsOptInStatus.optedIn) {
+  const isCorrectId = /0x[0-9,a-f, A-F]{48}/
+
+  if (!isCorrectId.test(currentId) && status === MetricsOptInStatus.optedIn) {
     metricsStore.set('metricsId', generateRandomId())
     trackEvent({
       event: 'Metrics Error Correction'

--- a/src/backend/metrics/metrics.ts
+++ b/src/backend/metrics/metrics.ts
@@ -181,6 +181,24 @@ export const trackScreen = async (name: string, properties?: apiObject) => {
   }
 }
 
+/**
+ * In the event there was a failure generating the random metrics id on initial opt-in,
+ * this will correct the state by generating a new random id.
+ * A metrics event will be sent so that we can see how many users were affected.
+ */
+function ensureUniqueMetricsId() {
+  const currentId = metricsStore.get('metricsId')
+  const status = metricsStore.get('metricsOptInStatus')
+  if (currentId === ANONYMOUS_ID && status === MetricsOptInStatus.optedIn) {
+    metricsStore.set('metricsId', generateRandomId())
+    trackEvent({
+      event: 'Metrics Error Correction'
+    })
+  }
+}
+
+ensureUniqueMetricsId()
+
 export const changeMetricsOptInStatus = async (
   newStatus: MetricsOptInStatus.optedIn | MetricsOptInStatus.optedOut
 ): Promise<void> => {

--- a/src/backend/metrics/types.ts
+++ b/src/backend/metrics/types.ts
@@ -12,6 +12,12 @@ export interface MetricsOptOut {
   sensitiveProperties?: never
 }
 
+export interface MetricsErrorCorrection {
+  event: 'Metrics Error Correction'
+  properties?: never
+  sensitiveProperties?: never
+}
+
 export interface GameStoreConnectionStarted {
   event: 'Game Store Connection Started'
   properties?: {
@@ -213,6 +219,7 @@ export interface HyperPlayLaunched {
 export type PossibleMetricPayloads =
   | MetricsOptIn
   | MetricsOptOut
+  | MetricsErrorCorrection
   | GameStoreConnectionStarted
   | OnboardingStarted
   | OnboardingSkipped


### PR DESCRIPTION
Checks that an opted in user has a unique metrics id on app launch

Reports a 'Metrics Error Correction' event if the user is opted in but still has the anonymous id so that we will know how many people were affected historically

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
