### PR TITLE
refactor(webview): use keys in webview components routes

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -59,10 +59,13 @@ function App() {
             />
             <Route path="/library" element={<Library />} />
             <Route path="login" element={<Login />} />
-            <Route path="hyperplaystore" element={<WebView />} />
-            <Route path="epicstore" element={<WebView />} />
-            <Route path="gogstore" element={<WebView />} />
-            <Route path="wiki" element={<WebView />} />
+            <Route
+              path="hyperplaystore"
+              element={<WebView key="hyperplaystore" />}
+            />
+            <Route path="epicstore" element={<WebView key="epicstore" />} />
+            <Route path="gogstore" element={<WebView key="gogstore" />} />
+            <Route path="wiki" element={<WebView key="wiki" />} />
             <Route path="metamaskHome" element={<MetaMaskHome />} />
             <Route
               path="metamaskSecretPhrase"
@@ -76,9 +79,9 @@ function App() {
                 <Route path=":appName" element={<GamePage />} />
               </Route>
             </Route>
-            <Route path="/store-page" element={<WebView />} />
+            <Route path="/store-page" element={<WebView key="store-page" />} />
             <Route path="loginweb">
-              <Route path=":runner" element={<WebView />} />
+              <Route path=":runner" element={<WebView key="loginweb" />} />
             </Route>
             <Route path="settings">
               <Route path=":runner">


### PR DESCRIPTION
Here's a good explanation of the current behavior https://www.loom.com/share/b76e1dac916242788a2e81fa51df0a01 please watch first

By using different React keys, we can ensure that the webview is unmounted on navigation. See https://www.makeuseof.com/react-keys-avoid-component-conflict/

**The caveats with this approach are two, both cause by the webview being unmounted:**

1. The history is lost between navigation. If you go from one route that uses webview to another, you cannot use the webview's navigation go back arrow to go to the previous page.
2. Going to a different route makes the compontent to reload the page even if it has visited before. In the current implementation because the webview component is never unmounted, it seems the webview caches the urls.