### PR TITLE
[Fix] Main access codes

### DIFF
--- a/src/frontend/components/UI/ChannelNameSelection/index.tsx
+++ b/src/frontend/components/UI/ChannelNameSelection/index.tsx
@@ -13,7 +13,7 @@ interface ChannelNameSelectionProps {
 export default function ChannelNameSelection({
   channelNameToInstall,
   setChannelNameToInstall,
-  gameInfo,
+  gameInfo
 }: ChannelNameSelectionProps) {
   const { t } = useTranslation('gamepage')
   return (

--- a/src/frontend/components/UI/ChannelNameSelection/index.tsx
+++ b/src/frontend/components/UI/ChannelNameSelection/index.tsx
@@ -2,26 +2,20 @@ import React from 'react'
 import SelectField from '../SelectField'
 import { GameInfo } from 'common/types'
 import { translateChannelName } from 'frontend/screens/Library/constants'
-import TextInputField from 'frontend/components/UI/TextInputField'
 import { useTranslation } from 'react-i18next'
 
 interface ChannelNameSelectionProps {
   channelNameToInstall: string
   setChannelNameToInstall(name: string): void
   gameInfo: GameInfo
-  accessCode: string
-  setAccessCode(code: string): void
 }
 
 export default function ChannelNameSelection({
   channelNameToInstall,
   setChannelNameToInstall,
   gameInfo,
-  accessCode,
-  setAccessCode
 }: ChannelNameSelectionProps) {
   const { t } = useTranslation('gamepage')
-  const selectedChannel = gameInfo?.channels?.[channelNameToInstall]
   return (
     <>
       <SelectField
@@ -42,14 +36,6 @@ export default function ChannelNameSelection({
             })
           : null}
       </SelectField>
-      {selectedChannel?.license_config.access_codes ? (
-        <TextInputField
-          placeholder={'Enter access code'}
-          value={accessCode}
-          onChange={(ev) => setAccessCode(ev.target.value)}
-          htmlId="access_code_input"
-        ></TextInputField>
-      ) : null}
     </>
   )
 }

--- a/src/frontend/screens/Library/components/InstallModal/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/index.tsx
@@ -26,6 +26,7 @@ import WineSelector from './WineSelector'
 import { getPlatformName } from 'frontend/helpers'
 import PlatformSelection from 'frontend/components/UI/PlatformSelection'
 import ChannelNameSelection from 'frontend/components/UI/ChannelNameSelection'
+import TextInputField from 'frontend/components/UI/TextInputField'
 
 type Props = {
   appName: string
@@ -188,9 +189,16 @@ export default React.memo(function InstallModal({
                 channelNameToInstall={channelNameToInstall}
                 setChannelNameToInstall={setChannelNameToInstall}
                 gameInfo={gameInfo}
-                accessCode={accessCode}
-                setAccessCode={setAccessCode}
               />
+            ) : null}
+            {runner === 'hyperplay' &&
+            selectedChannel?.license_config.access_codes ? (
+              <TextInputField
+                placeholder={'Enter access code'}
+                value={accessCode}
+                onChange={(ev) => setAccessCode(ev.target.value)}
+                htmlId="access_code_input"
+              ></TextInputField>
             ) : null}
             {hasWine ? (
               <WineSelector


### PR DESCRIPTION
Previously access code input would only show when there was >1 channel available.

For games that are only gating main, this would cause the access code text input field to be hidden

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
