### PR TITLE
[Fix] Browser Game Keyboard Input

### DIFF
--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -93,13 +93,11 @@ const openNewBrowserGameWindow = async (
       event: Electron.Event,
       input: Electron.Input
     ) {
-      logInfo(
-        `before input event in browser game window with input key = ${input.key}`,
-        LogPrefix.HyperPlay
-      )
-      if (input.key === 'F11' && input.type === 'keyDown') toggleFullscreen()
-      // this fixes DFK fullscreen toggle and ensures toggling is not called twice in dev mode
-      event.preventDefault()
+      if (input.key === 'F11' && input.type === 'keyDown') {
+        toggleFullscreen()
+        // this fixes DFK fullscreen toggle and ensures toggling is not called twice in dev mode
+        event.preventDefault()
+      }
     }
 
     function checkContentsUrlBeforeHandling(contents: Electron.WebContents) {


### PR DESCRIPTION
Some browser games are having their keyboard input blocked due to these missing brackets

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
