### PR TITLE
[Fix] Games with spaces in version name are always updateable

### DIFF
--- a/src/backend/storeManagers/hyperplay/games.ts
+++ b/src/backend/storeManagers/hyperplay/games.ts
@@ -391,9 +391,10 @@ export async function install(
 
     const [releaseMeta, selectedChannel] = getReleaseMeta(gameInfo, channelName)
 
-    
     const releaseVersion: string | undefined = sanitizeVersion(releaseMeta.name)
-    const gameInfoVersion = gameInfo.version ? sanitizeVersion(gameInfo.version) : ''
+    const gameInfoVersion = gameInfo.version
+      ? sanitizeVersion(gameInfo.version)
+      : ''
 
     if (platformToInstall === 'Browser') {
       const browserGameInstalledInfo: InstalledInfo = {

--- a/src/backend/storeManagers/hyperplay/games.ts
+++ b/src/backend/storeManagers/hyperplay/games.ts
@@ -39,7 +39,8 @@ import {
 import {
   getHyperPlayStoreRelease,
   handleArchAndPlatform,
-  handlePlatformReversed
+  handlePlatformReversed,
+  sanitizeVersion
 } from './utils'
 import { getSettings as getSettingsSideload } from 'backend/storeManagers/sideload/games'
 import {
@@ -390,7 +391,9 @@ export async function install(
 
     const [releaseMeta, selectedChannel] = getReleaseMeta(gameInfo, channelName)
 
-    const releaseVersion: string | undefined = releaseMeta.name
+    
+    const releaseVersion: string | undefined = sanitizeVersion(releaseMeta.name)
+    const gameInfoVersion = gameInfo.version ? sanitizeVersion(gameInfo.version) : ''
 
     if (platformToInstall === 'Browser') {
       const browserGameInstalledInfo: InstalledInfo = {
@@ -399,7 +402,7 @@ export async function install(
         executable: '',
         install_size: '0',
         is_dlc: false,
-        version: releaseVersion ? releaseVersion : gameInfo.version ?? '0',
+        version: releaseVersion ? releaseVersion : gameInfoVersion ?? '0',
         platform: 'web',
         channelName
       }
@@ -489,7 +492,7 @@ export async function install(
         executable: executable,
         install_size: platformInfo.installSize ?? '0',
         is_dlc: false,
-        version: releaseVersion ? releaseVersion : gameInfo.version ?? '0',
+        version: releaseVersion ? releaseVersion : gameInfoVersion ?? '0',
         platform: appPlatform,
         channelName
       }

--- a/src/backend/storeManagers/hyperplay/games.ts
+++ b/src/backend/storeManagers/hyperplay/games.ts
@@ -391,10 +391,12 @@ export async function install(
 
     const [releaseMeta, selectedChannel] = getReleaseMeta(gameInfo, channelName)
 
-    const releaseVersion: string | undefined = sanitizeVersion(releaseMeta.name)
+    const releaseVersion: string = sanitizeVersion(releaseMeta.name)
     const gameInfoVersion = gameInfo.version
       ? sanitizeVersion(gameInfo.version)
       : ''
+
+    const installVersion = releaseVersion ?? gameInfoVersion ?? '0'
 
     if (platformToInstall === 'Browser') {
       const browserGameInstalledInfo: InstalledInfo = {
@@ -403,7 +405,7 @@ export async function install(
         executable: '',
         install_size: '0',
         is_dlc: false,
-        version: releaseVersion ? releaseVersion : gameInfoVersion ?? '0',
+        version: installVersion,
         platform: 'web',
         channelName
       }
@@ -493,7 +495,7 @@ export async function install(
         executable: executable,
         install_size: platformInfo.installSize ?? '0',
         is_dlc: false,
-        version: releaseVersion ? releaseVersion : gameInfoVersion ?? '0',
+        version: installVersion,
         platform: appPlatform,
         channelName
       }

--- a/src/backend/storeManagers/hyperplay/library.ts
+++ b/src/backend/storeManagers/hyperplay/library.ts
@@ -13,6 +13,7 @@ import {
   getGameInfoFromHpRelease,
   getHyperPlayReleaseMap,
   handleArchAndPlatform,
+  sanitizeVersion,
   refreshGameInfoFromHpRelease
 } from './utils'
 import { getGameInfo as getGamesGameInfo } from './games'
@@ -206,10 +207,10 @@ export async function listUpdateableGames(): Promise<string[]> {
         To continue to receive game updates, uninstall and reinstall this game: ${val.title}`)
       }
       if (
+        // games installed before 0.5.0 used gameInfo.version for install.version
+        // so for backwards compatibility we remove spaces and lower case channel release meta name here 
         val.install.version !==
-          val.channels[val.install.channelName].release_meta.name
-            ?.toLowerCase()
-            .replaceAll(' ', '') ||
+        sanitizeVersion(val.channels[val.install.channelName].release_meta.name) ||
         ''
       ) {
         updateableGames.push(val.app_name)

--- a/src/backend/storeManagers/hyperplay/library.ts
+++ b/src/backend/storeManagers/hyperplay/library.ts
@@ -208,9 +208,11 @@ export async function listUpdateableGames(): Promise<string[]> {
       }
       if (
         // games installed before 0.5.0 used gameInfo.version for install.version
-        // so for backwards compatibility we remove spaces and lower case channel release meta name here 
+        // so for backwards compatibility we remove spaces and lower case channel release meta name here
         val.install.version !==
-        sanitizeVersion(val.channels[val.install.channelName].release_meta.name) ||
+          sanitizeVersion(
+            val.channels[val.install.channelName].release_meta.name
+          ) ||
         ''
       ) {
         updateableGames.push(val.app_name)

--- a/src/backend/storeManagers/hyperplay/library.ts
+++ b/src/backend/storeManagers/hyperplay/library.ts
@@ -210,10 +210,9 @@ export async function listUpdateableGames(): Promise<string[]> {
         // games installed before 0.5.0 used gameInfo.version for install.version
         // so for backwards compatibility we remove spaces and lower case channel release meta name here
         val.install.version !==
-          sanitizeVersion(
-            val.channels[val.install.channelName].release_meta.name
-          ) ||
-        ''
+        sanitizeVersion(
+          val.channels[val.install.channelName].release_meta.name || ''
+        )
       ) {
         updateableGames.push(val.app_name)
       }

--- a/src/backend/storeManagers/hyperplay/utils.ts
+++ b/src/backend/storeManagers/hyperplay/utils.ts
@@ -266,3 +266,7 @@ export async function loadEpicHyperPlayGameInfoMap() {
     }
   }
 }
+
+export function sanitizeVersion(ver: string){
+  return ver.toLowerCase().replaceAll(' ', '')
+}

--- a/src/backend/storeManagers/hyperplay/utils.ts
+++ b/src/backend/storeManagers/hyperplay/utils.ts
@@ -267,6 +267,6 @@ export async function loadEpicHyperPlayGameInfoMap() {
   }
 }
 
-export function sanitizeVersion(ver: string){
+export function sanitizeVersion(ver: string) {
   return ver.toLowerCase().replaceAll(' ', '')
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1594,24 +1594,12 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.0.tgz#76467a94aa888aeb22aafa43eb6ff889df3a5a7f"
   integrity sha512-rBevIsj2nclStJ7AxTdfsa3ovHb1H+qApwrxcTVo+NNdeJiB9V75hsKfrkG5AwNcRUNxrPPiScGYCNmLMoh8pg==
 
-"@fortawesome/fontawesome-common-types@6.4.2":
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.2.tgz#1766039cad33f8ad87f9467b98e0d18fbc8f01c5"
-  integrity sha512-1DgP7f+XQIJbLFCTX1V2QnxVmpLdKdzzo2k8EmvDOePfchaIGQ9eCHj2up3/jNEbZuBqel5OxiaOJf37TWauRA==
-
 "@fortawesome/fontawesome-svg-core@^6.1.1":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.2.0.tgz#11856eaf4dd1d865c442ddea1eed8ee855186ba2"
   integrity sha512-Cf2mAAeMWFMzpLC7Y9H1I4o3wEU+XovVJhTiNG8ZNgSQj53yl7OCJaS80K4YjrABWZzbAHVaoHE1dVJ27AAYXw==
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.2.0"
-
-"@fortawesome/fontawesome-svg-core@^6.4.0":
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.2.tgz#37f4507d5ec645c8b50df6db14eced32a6f9be09"
-  integrity sha512-gjYDSKv3TrM2sLTOKBc5rH9ckje8Wrwgx1CxAPbN5N3Fm4prfi7NsJVWd1jklp7i5uSCVwhZS5qlhMXqLrpAIg==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "6.4.2"
 
 "@fortawesome/free-brands-svg-icons@^6.1.1":
   version "6.2.0"
@@ -1627,13 +1615,6 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.2.0"
 
-"@fortawesome/free-regular-svg-icons@^6.4.0":
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.4.2.tgz#aee79ed76ce5dd04931352f9d83700761b8b1b25"
-  integrity sha512-0+sIUWnkgTVVXVAPQmW4vxb9ZTHv0WstOa3rBx9iPxrrrDH6bNLsDYuwXF9b6fGm+iR7DKQvQshUH/FJm3ed9Q==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "6.4.2"
-
 "@fortawesome/free-solid-svg-icons@^6.1.1":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.2.0.tgz#8dcde48109354fd7a5ece8ea48d678bb91d4b5f0"
@@ -1641,24 +1622,10 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.2.0"
 
-"@fortawesome/free-solid-svg-icons@^6.4.0":
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.2.tgz#33a02c4cb6aa28abea7bc082a9626b7922099df4"
-  integrity sha512-sYwXurXUEQS32fZz9hVCUUv/xu49PEJEyUOsA51l6PU/qVgfbTb2glsTEaJngVVT8VqBATRIdh7XVgV1JF1LkA==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "6.4.2"
-
 "@fortawesome/react-fontawesome@^0.1.18":
   version "0.1.19"
   resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.19.tgz#2b36917578596f31934e71f92b7cf9c425fd06e4"
   integrity sha512-Hyb+lB8T18cvLNX0S3llz7PcSOAJMLwiVKBuuzwM/nI5uoBw+gQjnf9il0fR1C3DKOI5Kc79pkJ4/xB0Uw9aFQ==
-  dependencies:
-    prop-types "^15.8.1"
-
-"@fortawesome/react-fontawesome@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz#d90dd8a9211830b4e3c08e94b63a0ba7291ddcf4"
-  integrity sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==
   dependencies:
     prop-types "^15.8.1"
 
@@ -1680,13 +1647,6 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
-
-"@hyperplay/chains@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@hyperplay/chains/-/chains-0.0.2.tgz#329aabdd30d5f1c25233fcb342840624fff235d1"
-  integrity sha512-yex3/IOnmxtM1N0uU20cceVKUDAjAGFO0LKNxH45Nn+bbOaVgXJCsXqEk3NfVLGk08X71fSDzRCcX2UCSUwEmA==
-  dependencies:
-    axios "^1.4.0"
 
 "@hyperplay/ui@^0.1.14":
   version "0.1.14"
@@ -4542,15 +4502,6 @@ axios@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
   integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
-  dependencies:
-    follow-redirects "^1.15.0"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
-
-axios@^1.4.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.5.0.tgz#f02e4af823e2e46a9768cfc74691fdd0517ea267"
-  integrity sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==
   dependencies:
     follow-redirects "^1.15.0"
     form-data "^4.0.0"


### PR DESCRIPTION
Games that have spaces or uppercase letters will always show as needing an update under the current logic

The lower casing and whitespace removal is for backwards compatibility for games installed with clients <0.5.0, but this was not being done on install for new games.

The only game currently affected is Moonblasters

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
