### PR TITLE
[CI] Fix utils test rounding error

### DIFF
--- a/src/backend/__tests__/utils.test.ts
+++ b/src/backend/__tests__/utils.test.ts
@@ -198,7 +198,7 @@ describe('backend/utils.ts', () => {
         getBytesFromMB(totalSizeMB),
         lastProgressTime
       )
-      expect(etaString).toEqual('00:00:04')
+      expect(etaString).toEqual(expect.stringMatching(/00:00:0[4,5]/))
     })
 
     test('normal download minutes', () => {

--- a/src/backend/__tests__/utils.test.ts
+++ b/src/backend/__tests__/utils.test.ts
@@ -172,7 +172,7 @@ describe('backend/utils.ts', () => {
         getBytesFromMB(downloadSpeedMB),
         getBytesFromMB(totalSizeMB)
       )
-      expect(etaString).toEqual('00:00:09')
+      expect(etaString).toEqual(expect.stringMatching(/00:00:0[8,9]/))
     })
 
     test('downloaded > total size', () => {
@@ -210,7 +210,7 @@ describe('backend/utils.ts', () => {
         getBytesFromMB(downloadSpeedMB),
         getBytesFromMB(totalSizeMB)
       )
-      expect(etaString).toEqual('00:01:30')
+      expect(etaString).toEqual(expect.stringMatching(/00:01:[29,30]/))
     })
 
     test('normal download hours', () => {
@@ -222,7 +222,7 @@ describe('backend/utils.ts', () => {
         getBytesFromMB(downloadSpeedMB),
         getBytesFromMB(totalSizeMB)
       )
-      expect(etaString).toEqual('02:46:30')
+      expect(etaString).toEqual(expect.stringMatching(/02:46:[29,30]/))
     })
   })
 


### PR DESCRIPTION
This utils test sometimes fails due to small delays between when
`const lastProgressTime = Date.now().valueOf() - 1000 * 4` 
is called in the test and when 
`const elapsedSeconds = (Date.now() - lastProgressTime) / 1000`
is called in `calculateEta`

We should just accept 04 or 05 to pass the test

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
