### PR TITLE
[FIX] Open game links when using proton on linux

### DIFF
--- a/src/backend/game_config.ts
+++ b/src/backend/game_config.ts
@@ -251,7 +251,7 @@ class GameConfigV0 extends GameConfig {
       showMangohud,
       targetExe,
       useGameMode,
-      useSteamRuntime: wineVersion.type === 'proton',
+      useSteamRuntime: wineVersion.type === 'proton' ? true : useSteamRuntime,
       language: '' // we want to fallback to '' always here, fallback lang for games should be ''
     } as GameSettings
 

--- a/src/backend/game_config.ts
+++ b/src/backend/game_config.ts
@@ -251,7 +251,7 @@ class GameConfigV0 extends GameConfig {
       showMangohud,
       targetExe,
       useGameMode,
-      useSteamRuntime,
+      useSteamRuntime: wineVersion.type === 'proton',
       language: '' // we want to fallback to '' always here, fallback lang for games should be ''
     } as GameSettings
 

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -598,7 +598,6 @@ async function runWineCommand({
     }
 
     if (options?.logFile && existsSync(options.logFile)) {
-      writeFileSync(options.logFile, '')
       appendFileSync(
         options.logFile,
         `Wine Command: WINEPREFIX=${winePrefix} ${bin} ${commandParts.join(

--- a/src/frontend/screens/Settings/components/SteamRuntime.tsx
+++ b/src/frontend/screens/Settings/components/SteamRuntime.tsx
@@ -14,13 +14,14 @@ const SteamRuntime = () => {
   const { platform } = useContext(ContextProvider)
   const isLinux = platform === 'linux'
   const isWin = platform === 'win32'
-  const [useSteamRuntime, setUseSteamRuntime] = useSetting(
-    'useSteamRuntime',
-    false
-  )
   const [wineVersion] = useSetting('wineVersion', defaultWineVersion)
 
   const isProton = !isWin && wineVersion?.type === 'proton'
+
+  const [useSteamRuntime, setUseSteamRuntime] = useSetting(
+    'useSteamRuntime',
+    isProton
+  )
 
   const showSteamRuntime = isLinuxNative || isProton
 


### PR DESCRIPTION
These changes enable Steam Runtime by default when using Proton on Linux, without it, on builds that are not-flatpak links inside games won't open a browser.

More details on #469

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
