### PR TITLE
[Feat] Add remove from library option to game card

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -65,6 +65,7 @@
             "continue": "Continue Download",
             "remove": "Remove from Queue"
         },
+        "remove_from_library": "Remove",
         "remove_from_recent": "Remove From Recent",
         "run-exe-first": "Run Installer First",
         "running-setup": "Running Setup",
@@ -156,9 +157,6 @@
         "title": "You are NOT logged in"
     },
     "report_problem": "Report a problem running this game",
-    "sdl": {
-        "title": "Select components to Install"
-    },
     "setting": {
         "use-default-wine-settings": "Use Default Compatibility Settings",
         "winecrossoverbottle": "CrossOver Bottle"

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -181,7 +181,9 @@
         "size": "Size",
         "title": "Title"
     },
-    "docs": "Documentation",
+    "dlcs": {
+        "label": "Select DLCs to install:"
+    },
     "download-manager": {
         "ETA": "Estimated Time",
         "install-type": {
@@ -244,6 +246,7 @@
         "custom_themes_path": "Do not use CSS files from untrusted sources. When in doubt, ask for a review in our Discord channel.",
         "custom_themes_wiki": "Check the Wiki for more details on adding custom themes. Click here.",
         "dxvk": "DXVK is a Vulkan-based translational layer for DirectX 9, 10 and 11 games. Enabling may improve compatibility. Might cause issues especially for older DirectX games.",
+        "dxvkfpslimit": "Sets a frame rate cap for DXVK games",
         "esync": "Esync aims to reduce wineserver overhead in CPU-intensive games. Enabling may improve performance.",
         "fsync": "Fsync aims to reduce wineserver overhead in CPU-intensive games. Enabling may improve performance on supported Linux kernels.",
         "game_language": {
@@ -550,6 +553,7 @@
         "alt-gogdl-bin": "Using built-in GOGDL binary...",
         "alt-legendary-bin": "Using built-in Legendary binary...",
         "custom_themes_path": "Select the path to look for custom CSS files",
+        "dxvkfpsvalue": "Positive integer value (e.g. 30, 60, ...)",
         "egs-prefix": "Prefix where EGS is installed",
         "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
@@ -592,6 +596,7 @@
         "disable_controller": "Disable HyperPlay navigation using controller",
         "discordRPC": "Enable Discord Rich Presence",
         "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
+        "dxvkfpslimit": "Limit FPS (DX9, 10 and 11)",
         "egs-sync": "Sync with Installed Epic Games",
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",
         "eosOverlay": {

--- a/src/backend/api/library.ts
+++ b/src/backend/api/library.ts
@@ -112,3 +112,7 @@ export const onLibraryChange = async (
     ipcRenderer.removeListener('onLibraryChanged', callback)
   }
 }
+
+export const removeFromLibrary = async (appName: string) => {
+  ipcRenderer.send('removeFromLibrary', appName)
+}

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1296,6 +1296,10 @@ ipcMain.handle(
   }
 )
 
+ipcMain.on('removeFromLibrary', (event, appName) => {
+  HyperPlayLibraryManager.removeFromLibrary(appName)
+})
+
 ipcMain.handle('repair', async (event, appName, runner) => {
   if (!isOnline()) {
     logWarning(
@@ -1853,7 +1857,6 @@ ipcMain.on('reloadApp', async () => {
 })
 
 ipcMain.handle('addHyperplayGame', async (_e, projectId) => {
-  console.log('addHyperplayGame', projectId)
   await addGameToLibrary(projectId)
 })
 

--- a/src/backend/storeManagers/hyperplay/library.ts
+++ b/src/backend/storeManagers/hyperplay/library.ts
@@ -230,6 +230,14 @@ export async function listUpdateableGames(): Promise<string[]> {
   return updateableGames
 }
 
+export function removeFromLibrary(appName: string) {
+  const currentHpLibrary = hpLibraryStore.get('games', [])
+  const newHpLibrary = currentHpLibrary.filter(
+    (val) => val.app_name !== appName
+  )
+  hpLibraryStore.set('games', newHpLibrary)
+}
+
 /* eslint-disable @typescript-eslint/no-unused-vars */
 export async function runRunnerCommand(
   commandParts: string[],

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -64,6 +64,7 @@ interface HyperPlaySyncIPCFunctions {
   addHyperPlayShortcut: (gameId: string) => void
   ignoreExitToTray: () => void
   setQaToken: (qaToken: string) => void
+  removeFromLibrary: (appName: string) => void
 }
 
 interface SyncIPCFunctions extends HyperPlaySyncIPCFunctions {

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -198,6 +198,10 @@ const GameCard = ({
     setShowUninstallModal(true)
   }
 
+  const onRemoveFromLibraryClick = function () {
+    window.api.removeFromLibrary(gameInfo.app_name)
+  }
+
   const handleClickStopBubbling =
     (callback: () => void, isRightClick = false) =>
     (
@@ -306,6 +310,13 @@ const GameCard = ({
       label: t('button.uninstall'),
       onClick: handleClickStopBubbling(onUninstallClick),
       show: isInstalled && !isUpdating
+    },
+    {
+      // remove from library
+      label: t('button.remove_from_library', 'Remove'),
+      onClick: handleClickStopBubbling(onRemoveFromLibraryClick),
+      show:
+        !isInstalled && !isUpdating && !isInstalling && runner === 'hyperplay'
     }
   ]
 


### PR DESCRIPTION
Right click an uninstalled HyperPlay game card and click "Remove" to remove it from your library json file

![image](https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/assets/27568879/1f170cd6-33ed-44fc-b290-f03603347d60)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
