### PR TITLE
[UI] Update metamask container to be position fixed

### DIFF
--- a/src/frontend/ExtensionManager/index.module.scss
+++ b/src/frontend/ExtensionManager/index.module.scss
@@ -1,11 +1,11 @@
 .mmContainer {
-  position: absolute;
+  position: fixed;
   right: 357px;
   display: flex;
   flex-direction: row;
   gap: 20px;
   z-index: 100000;
-  top: 0px;
+  top: var(--top-navbar-height);
 }
 
 .mmWindow {

--- a/src/frontend/components/UI/TopNavBar/index.module.scss
+++ b/src/frontend/components/UI/TopNavBar/index.module.scss
@@ -1,5 +1,5 @@
 .navBar {
-  height: 80px;
+  height: var(--top-navbar-height);
   background-color: var(--color-neutral-700);
   width: 100%;
   grid-column: 1 / -1;

--- a/src/frontend/index.scss
+++ b/src/frontend/index.scss
@@ -7,6 +7,7 @@
   /* Effects */
   --blur-light: 4px;
   --blur-strong: 16px;
+  --top-navbar-height: 80px;
 }
 
 // Example breakpoint


### PR DESCRIPTION
Before, scrolling would hide the MetaMask popup and notification windows on the library.
![image](https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/assets/27568879/16f797d0-d96c-4e54-b96a-cb7944f872d2)

With this PR, it now stays fixed
![image](https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/assets/27568879/84b70a10-b1a0-406c-82b7-6e685ba97f23)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
