### PR TITLE
[Chore] Update electron to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -297,7 +297,7 @@
     "@valist/sdk": "^2.9.1",
     "@vitejs/plugin-react": "^2.2.0",
     "cross-env": "^7.0.3",
-    "electron": "25.2.0",
+    "electron": "26.2.1",
     "electron-builder": "^24.6.3",
     "electron-devtools-installer": "^3.2.0",
     "electron-playwright-helpers": "^1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6057,10 +6057,10 @@ electron-vite@^1.0.23:
     magic-string "^0.30.0"
     picocolors "^1.0.0"
 
-electron@25.2.0:
-  version "25.2.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-25.2.0.tgz#ff832d88f78481a82cf9feb72e605ec43553d4ba"
-  integrity sha512-I/rhcW2sV2fyiveVSBr2N7v5ZiCtdGY0UiNCDZgk2fpSC+irQjbeh7JT2b4vWmJ2ogOXBjqesrN9XszTIG6DHg==
+electron@26.2.1:
+  version "26.2.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-26.2.1.tgz#2ef86c03d9753647622bb9a53c4213fb290e5eac"
+  integrity sha512-SNT24Cf/wRvfcFZQoERXjzswUlg5ouqhIuA2t9x2L7VdTn+2Jbs0QXRtOfzcnOV/raVMz3e8ICyaU2GGeciKLg==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"


### PR DESCRIPTION
Resolves dependabot alerts https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/pull/534

Might as well update to latest instead of 25.8.1

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
