### PR TITLE
[Fix] MetaMask snaps external link

### DIFF
--- a/src/frontend/ExtensionManager/index.tsx
+++ b/src/frontend/ExtensionManager/index.tsx
@@ -24,6 +24,7 @@ const animation = {
 
 const ExtensionManager = function () {
   const rootRef = useRef<HTMLDivElement>(null)
+  const trueAsStr = 'true' as unknown as boolean | undefined
 
   /* eslint-disable react/no-unknown-property */
   return (
@@ -36,6 +37,7 @@ const ExtensionManager = function () {
               webpreferences="contextIsolation=true, nodeIntegration=true"
               src={`chrome-extension://${extensionStore.extensionId}/popup.html`}
               className={ExtensionManagerStyles.mmWindow}
+              allowpopups={trueAsStr}
             ></webview>
           </motion.div>
         ) : null}
@@ -46,6 +48,7 @@ const ExtensionManager = function () {
               webpreferences="contextIsolation=true, nodeIntegration=true"
               src={`chrome-extension://${extensionStore.extensionId}/notification.html`}
               className={ExtensionManagerStyles.mmWindow}
+              allowpopups={trueAsStr}
             ></webview>
           </motion.div>
         ) : null}


### PR DESCRIPTION
Allows mm popup and notification windows to open external windows. Necessary to open snaps page

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
