### PR TITLE
[UX] Improve Download Toast

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.1.18",
+    "@hyperplay/ui": "^0.1.27",
     "@mantine/carousel": "^6.0.19",
     "@mantine/core": "^6.0.19",
     "@mantine/hooks": "^6.0.19",

--- a/package.json
+++ b/package.json
@@ -156,7 +156,6 @@
     "@fortawesome/free-regular-svg-icons": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.1.18",
-    "@hyperplay/ui": "^0.1.27",
     "@mantine/carousel": "^6.0.19",
     "@mantine/core": "^6.0.19",
     "@mantine/hooks": "^6.0.19",

--- a/src/backend/__tests__/services/ExtractZipService.test.ts
+++ b/src/backend/__tests__/services/ExtractZipService.test.ts
@@ -162,7 +162,7 @@ describe('ExtractZipService', () => {
     expect(progressListener).not.toHaveBeenCalled()
   })
 
-  it('should have the state as cancelled once is cancelled', async () => {
+  it('should have the state as canceled once is canceled', async () => {
     extractZipService.extract()
     extractZipService.cancel()
 

--- a/src/backend/__tests__/services/ExtractZipService.test.ts
+++ b/src/backend/__tests__/services/ExtractZipService.test.ts
@@ -101,13 +101,13 @@ const yauzlMockupLib = (
     openReadStream: jest.fn((entry, openReadStreamCallback) => {
       openReadStreamCallback(error, stream)
     })
-  };
+  }
 
-  (yauzl.open as jest.Mock).mockImplementation(
+  ;(yauzl.open as jest.Mock).mockImplementation(
     (_path, _options, yauzlOpenCallback) => {
       yauzlOpenCallback(error, mockZipFile)
     }
-  );
+  )
 
   const makeFakeProgress = () => {
     for (let i = 0; i < 1000; i++) {
@@ -121,7 +121,7 @@ const yauzlMockupLib = (
     openReadStream: mockZipFile.openReadStream,
     zipFile: mockZipFile,
     makeFakeProgress,
-    stream,
+    stream
   }
 }
 
@@ -157,9 +157,9 @@ describe('ExtractZipService', () => {
     extractZipService.extract()
 
     process.nextTick(() => {
-        makeFakeProgress();
+      makeFakeProgress()
 
-        expect(progressListener).toHaveBeenCalled()
+      expect(progressListener).toHaveBeenCalled()
     })
   })
 
@@ -291,7 +291,7 @@ describe('ExtractZipService', () => {
     extractZipService.pause()
 
     process.nextTick(() => {
-      makeFakeProgress();
+      makeFakeProgress()
 
       expect(pausedListener).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -314,7 +314,7 @@ describe('ExtractZipService', () => {
     extractZipService.pause()
 
     process.nextTick(() => {
-      makeFakeProgress();
+      makeFakeProgress()
 
       expect(resumedListener).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -336,7 +336,7 @@ describe('ExtractZipService', () => {
     extractZipService.extract()
     extractZipService.pause()
 
-    makeFakeProgress();
+    makeFakeProgress()
 
     expect(progressListener).not.toHaveBeenCalled()
   })
@@ -353,7 +353,7 @@ describe('ExtractZipService', () => {
     process.nextTick(() => {
       extractZipService.resume()
 
-      makeFakeProgress();
+      makeFakeProgress()
 
       expect(progressListener).toHaveBeenCalled()
     })
@@ -370,7 +370,7 @@ describe('ExtractZipService', () => {
     await extractZipService.extract()
 
     process.nextTick(() => {
-      makeFakeProgress();
+      makeFakeProgress()
 
       expect(onProgress).toHaveBeenCalled()
       expect(onEnd).toHaveBeenCalled()
@@ -387,7 +387,7 @@ describe('ExtractZipService', () => {
     extractZipService.extract()
 
     process.nextTick(() => {
-      makeFakeProgress();
+      makeFakeProgress()
 
       expect(mockEventListener).toHaveBeenCalledTimes(1)
     })

--- a/src/backend/__tests__/services/ExtractZipService.test.ts
+++ b/src/backend/__tests__/services/ExtractZipService.test.ts
@@ -1,0 +1,248 @@
+import { EventEmitter } from 'node:events'
+import yauzl from 'yauzl'
+import { resolve } from 'path'
+import { mkdirSync } from 'graceful-fs'
+import { ExtractZipService } from '../../services/ExtractZipService'
+
+const returnDataMockup = {
+  progressPercentage: 0,
+  speed: 0,
+  totalSize: 1000,
+  processedSize: 500
+}
+
+jest.mock('yauzl', () => ({
+  open: jest.fn()
+}))
+jest.mock('graceful-fs', () => ({
+  mkdirSync: jest.fn(),
+  createWriteStream: () => ({
+    pipe: jest.fn((writeStream) => writeStream),
+    once: jest.fn(),
+    on: jest.fn((event, streamCallback) => {
+      if (event === 'close') {
+        streamCallback()
+      } else if (event === 'data') {
+        streamCallback(new Array(500).fill(0))
+      } else if (event === 'error') {
+        streamCallback(new Error('Error'))
+      }
+    })
+  }),
+  rm: jest.fn(),
+  copyFileSync: jest.fn()
+}))
+
+const yauzlMockupLib = (
+  fileName = 'test.zip',
+  withError?: boolean,
+  fileSize = 1000
+) => {
+  const error = withError ? new Error('Error example') : null
+
+  const stream = {
+    _read: () => null,
+    pipe: jest.fn((args) => args),
+    on: jest.fn(
+      (
+        event: string,
+        streamCallback: (...args: unknown[]) => ReadableStream
+      ) => {
+        if (event === 'close') {
+          streamCallback()
+        } else if (event === 'data') {
+          streamCallback(new Array(500).fill(0))
+        } else if (event === 'error') {
+          streamCallback(new Error('Error'))
+        }
+      }
+    )
+  }
+
+  const mockZipFile = {
+    fileSize,
+    readEntry: jest.fn(),
+    close: jest.fn(),
+    once: jest.fn((event, streamCallback) => {
+      if (event === 'end') {
+        streamCallback()
+      }
+    }),
+    on: jest.fn((event, entryCallback) => {
+      if (event === 'entry') {
+        entryCallback({
+          fileName,
+          uncompressedSize: 1000
+        })
+      }
+    }),
+    openReadStream: jest.fn((entry, openReadStreamCallback) => {
+      openReadStreamCallback(error, stream)
+    })
+  }
+
+  ;(yauzl.open as jest.Mock).mockImplementation(
+    (_path, _options, yauzlOpenCallback) => {
+      yauzlOpenCallback(error, mockZipFile)
+    }
+  )
+
+  return {
+    openReadStream: mockZipFile.openReadStream,
+    zipFile: mockZipFile,
+    stream
+  }
+}
+
+describe('ExtractZipService', () => {
+  let extractZipService: ExtractZipService
+  const zipFile = resolve('./src/backend/__mocks__/test.zip')
+  const destinationPath = resolve('./src/backend/__mocks__/test')
+
+  beforeEach((done) => {
+    yauzlMockupLib('test.zip', false)
+    extractZipService = new ExtractZipService(zipFile, destinationPath)
+    setTimeout(done, 1000)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('should have `source` and `destination` always available', () => {
+    it('should initialize properly', () => {
+      expect(extractZipService).toBeInstanceOf(EventEmitter)
+      expect(extractZipService.source).toBe(zipFile)
+      expect(extractZipService.destination).toBe(destinationPath)
+    })
+  })
+
+  it('should emit progress events', async () => {
+    const progressListener = jest.fn()
+    extractZipService.on('progress', progressListener)
+
+    await extractZipService.extract()
+
+    expect(progressListener).toHaveBeenCalled()
+  })
+
+  it('should emit end event on successful extraction', async () => {
+    const endListener = jest.fn()
+    extractZipService.on('end', endListener)
+
+    await extractZipService.extract()
+
+    expect(endListener).toHaveBeenCalled()
+  })
+
+  it('should emit error event on extraction failure', async () => {
+    yauzlMockupLib('test.zip', true)
+
+    const errorListener = jest.fn()
+    extractZipService.on('error', errorListener)
+
+    await extractZipService.extract()
+
+    expect(errorListener).toHaveBeenCalledWith(
+      expect.objectContaining(new Error('Mock example'))
+    )
+  })
+
+  it('should cancel extraction when cancel is called', async () => {
+    const endListener = jest.fn()
+    const progressListener = jest.fn()
+    extractZipService.on('end', endListener)
+    extractZipService.on('progress', progressListener)
+
+    extractZipService.cancel()
+
+    await extractZipService.extract()
+
+    expect(endListener).not.toHaveBeenCalled()
+    expect(progressListener).not.toHaveBeenCalled()
+  })
+
+  it('should have the state as cancelled once is cancelled', async () => {
+    extractZipService.extract()
+    extractZipService.cancel()
+
+    expect(extractZipService.isCanceled).toBe(true)
+  })
+
+  it('should handle directory entry', async () => {
+    yauzlMockupLib('directory/test.zip', false)
+
+    const endListener = jest.fn()
+    extractZipService.on('end', endListener)
+
+    await extractZipService.extract()
+
+    expect(mkdirSync).toHaveBeenCalledWith(
+      expect.stringContaining('directory'),
+      expect.anything()
+    )
+    expect(endListener).toHaveBeenCalled()
+  })
+
+  it('should emit correct progress values', async () => {
+    const progressListener = jest.fn(() => returnDataMockup)
+    extractZipService.on('progress', progressListener)
+
+    await extractZipService.extract()
+
+    expect(progressListener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        processedSize: 500,
+        progressPercentage: 50,
+        speed: expect.any(Number),
+        totalSize: 1000
+      })
+    )
+  })
+
+  it('should emit correct end values', async () => {
+    const endListener = jest.fn(() => returnDataMockup)
+    extractZipService.on('end', endListener)
+
+    await extractZipService.extract()
+
+    expect(endListener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        processedSize: 500,
+        progressPercentage: 50,
+        speed: expect.any(Number),
+        totalSize: 1000
+      })
+    )
+  })
+
+  it('should extract files successfully', async () => {
+    const onProgress = jest.fn()
+    const onEnd = jest.fn()
+    extractZipService.on('progress', onProgress)
+    extractZipService.on('end', onEnd)
+
+    await extractZipService.extract()
+
+    expect(onProgress).toHaveBeenCalled()
+    expect(onEnd).toHaveBeenCalled()
+    expect(mkdirSync).toHaveBeenCalled()
+  })
+
+  it('should throttle emit progress', async () => {
+    const { stream } = yauzlMockupLib('test.zip')
+
+    const mockEventListener = jest.fn()
+    extractZipService.on('progress', mockEventListener)
+
+    await extractZipService.extract()
+
+    for (let i = 0; i < 10; i++) {
+      stream.on.mock.calls[stream.on.mock.calls.length - 1][1](
+        Buffer.alloc(500)
+      )
+    }
+
+    expect(mockEventListener).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/backend/__tests__/utils.test.ts
+++ b/src/backend/__tests__/utils.test.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 import { app } from 'electron'
 import * as utils from '../utils'
 import { test_data } from './test_data/github-api-heroic-test-data.json'
+import { logError } from '../logger/logger'
 
 jest.mock('electron')
 jest.mock('../logger/logger')

--- a/src/backend/__tests__/utils.test.ts
+++ b/src/backend/__tests__/utils.test.ts
@@ -1,18 +1,7 @@
 import axios from 'axios'
 import { app } from 'electron'
-import { extractZip } from '../../backend/utils'
-import { logError } from '../logger/logger'
 import * as utils from '../utils'
 import { test_data } from './test_data/github-api-heroic-test-data.json'
-import path from 'path'
-import {
-  copyFileSync,
-  existsSync,
-  readFileSync,
-  rmSync,
-  rmdirSync,
-  renameSync
-} from 'graceful-fs'
 
 jest.mock('electron')
 jest.mock('../logger/logger')
@@ -255,61 +244,6 @@ describe('backend/utils.ts', () => {
       expect(utils.bytesToSize(1024 * 1024 * 1029 * 44000)).toEqual('43.18 TB')
       expect(utils.bytesToSize(1025 * 1024 * 2056 * 21010)).toEqual('41.24 TB')
       expect(utils.bytesToSize(2059 * 1024 * 3045 * 4000)).toEqual('23.36 TB')
-    })
-  })
-
-  describe('extractZip', () => {
-    let testCopyZipPath: string
-    let destFilePath: string
-
-    beforeEach(() => {
-      const testZipPath = path.resolve('./src/backend/__mocks__/test.zip')
-      //copy zip because extract will delete it
-      testCopyZipPath = path.resolve('./src/backend/__mocks__/test2.zip')
-      copyFileSync(testZipPath, testCopyZipPath)
-      destFilePath = path.resolve('./src/backend/__mocks__/test')
-    })
-
-    afterEach(async () => {
-      const extractPromise = utils.extractZip(testCopyZipPath, destFilePath)
-      await extractPromise
-      expect(extractPromise).resolves
-
-      const testTxtFilePath = path.resolve(destFilePath, './test.txt')
-      console.log('checking dest file path ', testTxtFilePath)
-      expect(existsSync(testTxtFilePath)).toBe(true)
-
-      const testMessage = readFileSync(testTxtFilePath).toString()
-      console.log('unzipped file contents: ', testMessage)
-      expect(testMessage).toEqual('this is a test message')
-
-      //extract deletes the zip file used to extract async so we wait and then check
-      await utils.wait(100)
-      expect(existsSync(testCopyZipPath)).toBe(false)
-
-      //clean up test
-      rmSync(testTxtFilePath)
-      rmdirSync(destFilePath)
-      expect(existsSync(testTxtFilePath)).toBe(false)
-      expect(existsSync(destFilePath)).toBe(false)
-    })
-
-    test('extract a normal test zip', async () => {
-      console.log('extracting test.zip')
-    })
-
-    test('extract a test zip with non ascii characters', async () => {
-      const renamedZipFilePath = path.resolve(
-        './src/backend/__mocks__/谷���新道ひばりヶ�.zip'
-      )
-      renameSync(testCopyZipPath, renamedZipFilePath)
-      testCopyZipPath = renamedZipFilePath
-    })
-
-    it('should throw an error if the zip file does not exist', async () => {
-      await expect(
-        extractZip('nonexistent.zip', destFilePath)
-      ).rejects.toThrow()
     })
   })
 })

--- a/src/backend/api/downloadmanager.ts
+++ b/src/backend/api/downloadmanager.ts
@@ -78,6 +78,9 @@ export const handleDMQueueInformation = (
 export const cancelDownload = (removeDownloaded: boolean) =>
   ipcRenderer.send('cancelDownload', removeDownloaded)
 
+export const cancelExtraction = (appName: string) =>
+  ipcRenderer.send('cancelExtraction', appName)
+
 export const resumeCurrentDownload = () =>
   ipcRenderer.send('resumeCurrentDownload')
 

--- a/src/backend/downloadmanager/downloadqueue.ts
+++ b/src/backend/downloadmanager/downloadqueue.ts
@@ -188,6 +188,23 @@ function getQueueInformation() {
   return { elements, finished, state: queueState }
 }
 
+function cancelQueueExtraction() {
+  if (currentElement) {
+    if (Array.isArray(currentElement.params.installDlcs)) {
+      const dlcsToRemove = currentElement.params.installDlcs
+      for (const dlc of dlcsToRemove) {
+        removeFromQueue(dlc)
+      }
+    }
+    if (isRunning()) {
+      stopCurrentDownload()
+    }
+    removeFromQueue(currentElement.params.appName)
+
+    currentElement = null
+  }
+}
+
 function cancelCurrentDownload({ removeDownloaded = false }) {
   if (currentElement) {
     if (Array.isArray(currentElement.params.installDlcs)) {
@@ -255,8 +272,6 @@ function processNotification(element: DMQueueElement, status: DMStatus) {
     element.params.appName
   )
 
-  console.log('processNotification', status)
-
   if (status === 'abort') {
     if (isPaused()) {
       logWarning(
@@ -320,6 +335,7 @@ export {
   removeFromQueue,
   getQueueInformation,
   cancelCurrentDownload,
+  cancelQueueExtraction,
   pauseCurrentDownload,
   resumeCurrentDownload,
   getFirstQueueElement

--- a/src/backend/downloadmanager/ipc_handler.ts
+++ b/src/backend/downloadmanager/ipc_handler.ts
@@ -7,6 +7,7 @@ import {
   removeFromQueue,
   resumeCurrentDownload
 } from './downloadqueue'
+import { cancelExtraction } from 'backend/storeManagers/hyperplay/games'
 
 ipcMain.handle('addToDMQueue', async (e, element) => {
   await addToQueue(element)
@@ -24,6 +25,10 @@ ipcMain.handle('pauseCurrentDownload', async () => pauseCurrentDownload())
 
 ipcMain.on('cancelDownload', (e, removeDownloaded) => {
   cancelCurrentDownload({ removeDownloaded })
+})
+
+ipcMain.on('cancelExtraction', (e, appName: string) => {
+  cancelExtraction(appName)
 })
 
 ipcMain.handle('getDMQueueInformation', getQueueInformation)

--- a/src/backend/services/ExtractZipService.ts
+++ b/src/backend/services/ExtractZipService.ts
@@ -31,9 +31,8 @@ export class ExtractZipService extends EventEmitter {
 
   private zipFileInstance: ZipFile | null = null
   private extractionPromise: Promise<boolean | void> | null = null
-  private resolveExtraction: ((value: boolean) => void) | null = () => null
-  private rejectExtraction: ((reason: Error | unknown) => void) | null = () =>
-    null
+  private resolveExtraction: ((value: boolean) => void) | null = null
+  private rejectExtraction: ((reason: Error | unknown) => void) | null = null
 
   /**
    * Creates an instance of ExtractZipService.
@@ -42,6 +41,9 @@ export class ExtractZipService extends EventEmitter {
    */
   constructor(private zipFile: string, private destinationPath: string) {
     super()
+
+    this.resolveExtraction = () => null
+    this.rejectExtraction = () => null
   }
 
   /**

--- a/src/backend/services/ExtractZipService.ts
+++ b/src/backend/services/ExtractZipService.ts
@@ -1,0 +1,257 @@
+import { EventEmitter } from 'node:events'
+import { Readable } from 'node:stream';
+import { open, ZipFile } from 'yauzl'
+import { mkdirSync, createWriteStream, rm } from 'graceful-fs'
+import { join } from 'path'
+
+export interface ExtractZipProgressResponse {
+  /** Percentage of extraction progress. */
+  progressPercentage: number
+  /** Speed of extraction in bytes per second. */
+  speed: number
+  /** Total size of the ZIP file in bytes. */
+  totalSize: number
+  /** Size of the ZIP content processed so far in bytes. */
+  processedSize: number
+}
+
+/**
+ * Service class to handle extraction of ZIP files.
+ * @extends {EventEmitter}
+ */
+export class ExtractZipService extends EventEmitter {
+  private readStream: Readable | null = null;
+  private canceled = false
+  private paused = false;
+
+  private totalSize = 0
+  private processedSize = 0
+  private startTime = Date.now()
+  private lastUpdateTime = Date.now()
+  private dataDelay = 1000
+
+  private extractionPromise: Promise<boolean | void> | null = null;
+  private resolveExtraction: ((value: boolean) => void) | null = () => null;
+  private rejectExtraction: ((reason: Error) => void) | null = () => null;
+
+  /**
+   * Creates an instance of ExtractZipService.
+   * @param {string} zipFile - The path to the ZIP file.
+   * @param {string} destinationPath - The path where the extracted files should be saved.
+   */
+  constructor(
+    private zipFile: string,
+    private destinationPath: string,
+  ) {
+    super()
+  }
+
+  /**
+   * Checks if the extraction process was canceled.
+   * @returns {boolean} - True if the extraction was canceled, false otherwise.
+   */
+  get isCanceled(): boolean {
+    return this.canceled;
+  }
+
+  get isPaused(): boolean {
+    return this.readStream?.isPaused() || false;
+  }
+
+  /**
+   * Gets the source ZIP file path.
+   * @returns {string} - The path to the ZIP file.
+   */
+  get source(): string {
+    return this.zipFile;
+  }
+
+  /**
+   * Gets the destination path where files will be extracted.
+   * @returns {string} - The destination path.
+   */
+  get destination(): string {
+    return this.destinationPath;
+  }
+
+
+  public pause(): void {
+    if (!this.isPaused) {
+      this.readStream?.pause();
+    }
+  }
+
+  public async resume(): Promise<boolean | void> {
+    if (!this.extractionPromise) {
+      throw new Error('Extraction has not started or has already completed.');
+    }
+
+    if (this.isPaused) {
+      this.readStream?.resume();
+    }
+
+    return this.extractionPromise;
+  }
+
+  /**
+   * Cancels the extraction process.
+   */
+  public cancel() {
+    this.canceled = true
+    this.readStream?.destroy();
+  }
+
+  /**
+   * Computes the progress of the extraction process.
+   * @private
+   * @returns {ExtractZipProgressResponse} - The progress details.
+   */
+  private computeProgress(): ExtractZipProgressResponse {
+    const progressPercentage = Math.min(
+      100,
+      (this.processedSize / this.totalSize) * 100
+    )
+    const elapsedTime = (Date.now() - this.startTime) / 1000
+    const speed = this.processedSize / elapsedTime
+
+    return {
+      progressPercentage,
+      speed,
+      totalSize: this.totalSize,
+      processedSize: this.processedSize
+    }
+  }
+
+  /**
+   * Handles data events during extraction.
+   * @private
+   * @param {number} chunkLength - The length of the data chunk being processed.
+   */
+  private onData(chunkLength: number) {
+    if (this.canceled) {
+      return;
+    }
+
+    this.processedSize += chunkLength
+    const currentTime = Date.now()
+
+    // Make always sure to have a delay, unless it will be too much spam + performance issues eventually,
+    // especially on electron with webContents.send*
+    if (currentTime - this.lastUpdateTime > this.dataDelay) {
+      this.emit('progress', this.computeProgress())
+      this.lastUpdateTime = currentTime
+    }
+  }
+
+  /**
+   * Handles end events after extraction completes.
+   * @private
+   */
+  private onEnd() {
+    if (!this.canceled) {
+      this.emit('end', this.computeProgress())
+      rm(this.zipFile, console.log)
+    }
+  }
+
+  /**
+   * Handles error events during extraction.
+   * @private
+   * @param {Error} error - The error that occurred.
+   */
+  private onError(error: Error) {
+    this.emit('error', error)
+  }
+
+  /**
+   * Extracts the ZIP file to the specified destination.
+   * @returns {Promise<void>} - A promise that resolves when the extraction is complete.
+   */
+  async extract() {
+    this.extractionPromise = new Promise<boolean | void>((resolve, reject) => {
+      this.resolveExtraction = resolve;
+      this.rejectExtraction = reject;
+
+      open(this.zipFile, { lazyEntries: true }, (err, file: ZipFile) => {
+        if (err && this.rejectExtraction) {
+          this.rejectExtraction(err)
+          return
+        }
+
+        this.totalSize = file.fileSize
+
+        file.readEntry()
+
+        file.on('entry', (entry) => {
+          if (this.canceled) {
+            file.close()
+            return
+          }
+
+          if (/\/$/.test(entry.fileName)) {
+            // Directory file names end with '/'
+            mkdirSync(join(this.destinationPath, entry.fileName), {
+              recursive: true
+            })
+            file.readEntry()
+          } else {
+            // Ensure parent directory exists
+            mkdirSync(
+              join(
+                this.destinationPath,
+                entry.fileName.split('/').slice(0, -1).join('/')
+              ),
+              { recursive: true }
+            )
+
+            file.openReadStream(entry, (err, readStream) => {
+              if (err && this.rejectExtraction) {
+                this.rejectExtraction(err)
+                return
+              }
+
+              this.readStream = readStream;
+              const writeStream = createWriteStream(
+                join(this.destinationPath, entry.fileName)
+              )
+              readStream.pipe(writeStream)
+              readStream.on('data', (chunk) => {
+                this.onData(chunk.length)
+              })
+              writeStream.on('close', () => {
+                file.readEntry()
+              })
+            })
+          }
+        })
+
+        file.once('end', () => {
+          if (!this.canceled) {
+            file.close()
+            this.onEnd()
+          }
+
+          if (this.resolveExtraction) {
+            this.resolveExtraction(true)
+          }
+        })
+      })
+    }).catch((error) => {
+      this.onError(error);
+    })
+    try {
+      return await this.extractionPromise;
+    } catch (error: unknown) {
+      if (this.rejectExtraction) {
+        this.rejectExtraction(error as Error);
+      }
+    } finally {
+      this.extractionPromise = null;
+      this.resolveExtraction = null;
+      this.rejectExtraction = null;
+      this.removeAllListeners();
+    }
+
+    return false;
+  }
+}

--- a/src/backend/storeManagers/hyperplay/games.ts
+++ b/src/backend/storeManagers/hyperplay/games.ts
@@ -694,7 +694,7 @@ export async function install(
         }
       )
       extractService.once(
-        'end',
+        'finished',
         async ({
           progressPercentage,
           speed,

--- a/src/backend/storeManagers/hyperplay/games.ts
+++ b/src/backend/storeManagers/hyperplay/games.ts
@@ -509,7 +509,9 @@ export async function cancelExtraction(appName: string) {
     }
   } catch (error: unknown) {
     logInfo(
-      `cancelExtraction: Error while canceling the operation ${(error as Error).message} `,
+      `cancelExtraction: Error while canceling the operation ${
+        (error as Error).message
+      } `,
       LogPrefix.HyperPlay
     )
   }
@@ -657,7 +659,7 @@ export async function install(
     try {
       const extractService = new ExtractZipService(zipFile, destinationPath)
 
-      inProgressExtractionsMap.set(appName, extractService);
+      inProgressExtractionsMap.set(appName, extractService)
 
       extractService.on(
         'progress',
@@ -768,7 +770,7 @@ export async function install(
       )
       extractService.once('error', (error: Error) => {
         logError(`Extracting Error ${error.message}`, LogPrefix.HyperPlay)
-        
+
         cancelQueueExtraction()
         callAbortController(appName)
 
@@ -810,7 +812,7 @@ export async function install(
             eta: null
           }
         })
-    
+
         notify({
           title,
           body: 'Installation Stopped'
@@ -824,7 +826,7 @@ export async function install(
       await extractService.extract()
     } catch (error) {
       process.noAsar = false
-      
+
       logInfo(`Error while extracting game ${error}`, LogPrefix.HyperPlay)
       window.webContents.send('gameStatusUpdate', {
         appName,

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -15,7 +15,6 @@ import {
   ProgressInfo
 } from 'common/types'
 import axios from 'axios'
-import yauzl from 'yauzl'
 import download from 'backend/utils/downloadFile/download_file'
 import { File, Progress } from 'backend/utils/downloadFile/types'
 
@@ -39,11 +38,7 @@ import {
   appendFileSync,
   existsSync,
   rmSync,
-  mkdirSync,
-  createWriteStream,
-  rm
 } from 'graceful-fs'
-import { EventEmitter } from 'events';
 import { promisify } from 'util'
 import i18next, { t } from 'i18next'
 import si from 'systeminformation'
@@ -1418,7 +1413,6 @@ function removeFolder(path: string, folderName: string) {
   }
   return
 }
-
 
 export function calculateEta(
   downloadedBytes: number,

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -34,11 +34,7 @@ import {
   SpawnOptions,
   spawnSync
 } from 'child_process'
-import {
-  appendFileSync,
-  existsSync,
-  rmSync,
-} from 'graceful-fs'
+import { appendFileSync, existsSync, rmSync } from 'graceful-fs'
 import { promisify } from 'util'
 import i18next, { t } from 'i18next'
 import si from 'systeminformation'

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -126,6 +126,7 @@ interface SyncIPCFunctions extends HyperPlaySyncIPCFunctions {
   openGameInEpicStore: (url: string) => void
   resumeCurrentDownload: () => void
   cancelDownload: (removeDownloaded: boolean) => void
+  cancelExtraction: (appName: string) => void
   copyWalletConnectBaseURIToClipboard: () => void
 }
 

--- a/src/frontend/components/UI/DownloadToastManager/index.tsx
+++ b/src/frontend/components/UI/DownloadToastManager/index.tsx
@@ -1,11 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react'
 import { DownloadToast, Images, CircularButton } from '@hyperplay/ui'
-import {
-  DMQueueElement,
-  DownloadManagerState,
-  GameStatus,
-  InstallProgress
-} from 'common/types'
+import { DMQueueElement, GameStatus, InstallProgress } from 'common/types'
 import { DMQueue } from 'frontend/types'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { useTranslation } from 'react-i18next'

--- a/src/frontend/components/UI/DownloadToastManager/index.tsx
+++ b/src/frontend/components/UI/DownloadToastManager/index.tsx
@@ -253,6 +253,7 @@ downloadSizeInBytes = { adjustedDownloadSizeInBytes }
           folderName={folder_name}
           progress={progress}
           runner={runner}
+          status={status}
           onClose={() => setShowStopInstallModal(false)}
         />
       ) : null}

--- a/src/frontend/components/UI/DownloadToastManager/index.tsx
+++ b/src/frontend/components/UI/DownloadToastManager/index.tsx
@@ -34,6 +34,7 @@ export default function DownloadToastManager() {
     appName,
     gameInfo
   )
+  const isExtracting = status === 'extracting'
 
   let showPlayTimeout: NodeJS.Timeout | undefined = undefined
 
@@ -109,6 +110,12 @@ export default function DownloadToastManager() {
     }
   }, [currentElement])
 
+  useEffect(() => {
+    if (isExtracting) {
+      setProgress(nullProgress) // reset progress to 0
+    }
+  }, [isExtracting])
+
   if (currentElement === undefined) {
     console.debug('no downloads active in download toast manager')
     return <></>
@@ -158,18 +165,19 @@ export default function DownloadToastManager() {
     downloadedMB = Number(progress.bytes)
   }
 
-  const title = currentElement?.params.gameInfo.title
-    ? currentElement?.params.gameInfo.title
-    : 'Game'
-  const downloadSizeInMB = progress.percent
-    ? (downloadedMB / progress.percent) * 100
-    : 0
-  const estimatedCompletionTimeInMs = progress.downSpeed
-    ? (downloadSizeInMB / progress.downSpeed) * 1000
-    : 0
-  let imgUrl = currentElement?.params.gameInfo.art_cover
-    ? currentElement?.params.gameInfo.art_cover
-    : ''
+const title = currentElement?.params.gameInfo.title
+  ? currentElement?.params.gameInfo.title
+  : 'Game'
+const downloadSizeInMB = progress.percent
+  ? (downloadedMB / progress.percent) * 100
+  : 0
+const estimatedCompletionTimeInMs = progress.downSpeed
+  ? (downloadSizeInMB / progress.downSpeed) * 1000
+  : 0
+let imgUrl = currentElement?.params.gameInfo.art_cover
+  ? currentElement?.params.gameInfo.art_cover
+  : ''
+
   if (!imgUrl.includes('http'))
     imgUrl = currentElement.params.gameInfo.art_square
 
@@ -190,18 +198,18 @@ export default function DownloadToastManager() {
     return 'inProgress'
   }
 
+const adjustedDownloadedInBytes = downloadedMB * 1024 * 1024;
+const adjustedDownloadSizeInBytes = downloadSizeInMB * 1024 * 1024;
+
   return (
     <div className={DownloadToastManagerStyles.downloadManagerContainer}>
       {showDownloadToast ? (
         <DownloadToast
           imgUrl={imgUrl}
           gameTitle={title}
-          downloadedInBytes={
-            status === 'extracting'
-              ? downloadSizeInMB * 1024 * 1024
-              : downloadedMB * 1024 * 1024
-          }
-          downloadSizeInBytes={downloadSizeInMB * 1024 * 1024}
+downloadedInBytes = { adjustedDownloadedInBytes }
+downloadSizeInBytes = { adjustedDownloadSizeInBytes }
+
           estimatedCompletionTimeInMs={estimatedCompletionTimeInMs}
           onCancelClick={() => {
             setShowStopInstallModal(true)

--- a/src/frontend/components/UI/DownloadToastManager/index.tsx
+++ b/src/frontend/components/UI/DownloadToastManager/index.tsx
@@ -193,6 +193,7 @@ export default function DownloadToastManager() {
   const installPath = currentElement?.params.path
 
   function getDownloadStatus(): downloadStatus {
+    if (isExtracting) return 'inExtraction'
     if (dmState === 'paused') return 'paused'
     if (showPlay) return 'done'
     return 'inProgress'

--- a/src/frontend/components/UI/DownloadToastManager/index.tsx
+++ b/src/frontend/components/UI/DownloadToastManager/index.tsx
@@ -165,18 +165,18 @@ export default function DownloadToastManager() {
     downloadedMB = Number(progress.bytes)
   }
 
-const title = currentElement?.params.gameInfo.title
-  ? currentElement?.params.gameInfo.title
-  : 'Game'
-const downloadSizeInMB = progress.percent
-  ? (downloadedMB / progress.percent) * 100
-  : 0
-const estimatedCompletionTimeInMs = progress.downSpeed
-  ? (downloadSizeInMB / progress.downSpeed) * 1000
-  : 0
-let imgUrl = currentElement?.params.gameInfo.art_cover
-  ? currentElement?.params.gameInfo.art_cover
-  : ''
+  const title = currentElement?.params.gameInfo.title
+    ? currentElement?.params.gameInfo.title
+    : 'Game'
+  const downloadSizeInMB = progress.percent
+    ? (downloadedMB / progress.percent) * 100
+    : 0
+  const estimatedCompletionTimeInMs = progress.downSpeed
+    ? (downloadSizeInMB / progress.downSpeed) * 1000
+    : 0
+  let imgUrl = currentElement?.params.gameInfo.art_cover
+    ? currentElement?.params.gameInfo.art_cover
+    : ''
 
   if (!imgUrl.includes('http'))
     imgUrl = currentElement.params.gameInfo.art_square
@@ -198,8 +198,8 @@ let imgUrl = currentElement?.params.gameInfo.art_cover
     return 'inProgress'
   }
 
-const adjustedDownloadedInBytes = downloadedMB * 1024 * 1024;
-const adjustedDownloadSizeInBytes = downloadSizeInMB * 1024 * 1024;
+  const adjustedDownloadedInBytes = downloadedMB * 1024 * 1024
+  const adjustedDownloadSizeInBytes = downloadSizeInMB * 1024 * 1024
 
   return (
     <div className={DownloadToastManagerStyles.downloadManagerContainer}>
@@ -207,9 +207,8 @@ const adjustedDownloadSizeInBytes = downloadSizeInMB * 1024 * 1024;
         <DownloadToast
           imgUrl={imgUrl}
           gameTitle={title}
-downloadedInBytes = { adjustedDownloadedInBytes }
-downloadSizeInBytes = { adjustedDownloadSizeInBytes }
-
+          downloadedInBytes={adjustedDownloadedInBytes}
+          downloadSizeInBytes={adjustedDownloadSizeInBytes}
           estimatedCompletionTimeInMs={estimatedCompletionTimeInMs}
           onCancelClick={() => {
             setShowStopInstallModal(true)

--- a/src/frontend/components/UI/StopInstallationModal/index.tsx
+++ b/src/frontend/components/UI/StopInstallationModal/index.tsx
@@ -17,11 +17,14 @@ interface StopInstallProps {
   appName: string
   runner: Runner
   progress: InstallProgress
+  status: string
 }
 
 export default function StopInstallationModal(props: StopInstallProps) {
   const { t } = useTranslation('gamepage')
   const checkbox = useRef<HTMLInputElement>(null)
+  const isExtracting = props.status === 'extracting';
+
   return (
     <Dialog onClose={props.onClose} showCloseButton>
       <DialogHeader onClose={props.onClose}>
@@ -56,6 +59,7 @@ export default function StopInstallationModal(props: StopInstallProps) {
           type="secondary"
           size="large"
           onClick={async () => {
+            console.log('isExtracting', isExtracting)
             // if user wants to keep downloaded files and cancel download
             if (checkbox.current && checkbox.current.checked) {
               props.onClose()
@@ -68,12 +72,25 @@ export default function StopInstallationModal(props: StopInstallProps) {
                 folder: props.installPath
               }
               storage.setItem(props.appName, JSON.stringify(latestProgress))
+
+              if (isExtracting) {
+                window.api.cancelExtraction(props.appName)
+
+                return 
+              }
+
               window.api.cancelDownload(false)
             }
             // if user does not want to keep downloaded files but still wants to cancel download
             else {
               props.onClose()
-              window.api.cancelDownload(true)
+
+              if (isExtracting) {
+                window.api.cancelExtraction(props.appName)
+              } else {
+                window.api.cancelDownload(true)
+              }
+
               storage.removeItem(props.appName)
             }
           }}

--- a/src/frontend/components/UI/StopInstallationModal/index.tsx
+++ b/src/frontend/components/UI/StopInstallationModal/index.tsx
@@ -59,7 +59,6 @@ export default function StopInstallationModal(props: StopInstallProps) {
           type="secondary"
           size="large"
           onClick={async () => {
-            console.log('isExtracting', isExtracting)
             // if user wants to keep downloaded files and cancel download
             if (checkbox.current && checkbox.current.checked) {
               props.onClose()

--- a/src/frontend/components/UI/StopInstallationModal/index.tsx
+++ b/src/frontend/components/UI/StopInstallationModal/index.tsx
@@ -17,13 +17,13 @@ interface StopInstallProps {
   appName: string
   runner: Runner
   progress: InstallProgress
-  status: string
+  status?: string
 }
 
 export default function StopInstallationModal(props: StopInstallProps) {
   const { t } = useTranslation('gamepage')
   const checkbox = useRef<HTMLInputElement>(null)
-  const isExtracting = props.status === 'extracting';
+  const isExtracting = props.status === 'extracting'
 
   return (
     <Dialog onClose={props.onClose} showCloseButton>
@@ -76,7 +76,7 @@ export default function StopInstallationModal(props: StopInstallProps) {
               if (isExtracting) {
                 window.api.cancelExtraction(props.appName)
 
-                return 
+                return
               }
 
               window.api.cancelDownload(false)

--- a/src/frontend/hooks/hasStatus.ts
+++ b/src/frontend/hooks/hasStatus.ts
@@ -9,7 +9,7 @@ import libraryState from 'frontend/state/libraryState'
 // the consuming code needs to be wrapped in observer when using this hook
 export const hasStatus = (
   appName: string,
-  gameInfo: GameInfo,
+  gameInfo: GameInfo | undefined,
   gameSize?: string
 ) => {
   const { libraryStatus } = React.useContext(ContextProvider)
@@ -25,7 +25,7 @@ export const hasStatus = (
   const {
     thirdPartyManagedApp = undefined,
     is_installed,
-    runner
+    runner = 'hyperplay'
   } = { ...gameInfo }
 
   React.useEffect(() => {

--- a/src/frontend/hooks/hasStatus.ts
+++ b/src/frontend/hooks/hasStatus.ts
@@ -9,7 +9,7 @@ import libraryState from 'frontend/state/libraryState'
 // the consuming code needs to be wrapped in observer when using this hook
 export const hasStatus = (
   appName: string,
-  gameInfo: GameInfo | undefined,
+  gameInfo?: GameInfo,
   gameSize?: string
 ) => {
   const { libraryStatus } = React.useContext(ContextProvider)

--- a/src/frontend/hooks/useGetDmState.ts
+++ b/src/frontend/hooks/useGetDmState.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react'
+import { DMQueueElement, DownloadManagerState } from 'common/types'
+import { DMQueue } from 'frontend/types'
+
+export function useGetDmState() {
+  const [dmState, setDMState] = useState<DownloadManagerState>('idle')
+
+  useEffect(() => {
+    window.api.getDMQueueInformation().then(({ state }: DMQueue) => {
+      setDMState(state)
+    })
+
+    const removeHandleDMQueueInformation = window.api.handleDMQueueInformation(
+      (
+        e: Electron.IpcRendererEvent,
+        elements: DMQueueElement[],
+        state: DownloadManagerState
+      ) => {
+        if (elements) {
+          setDMState(state)
+        }
+      }
+    )
+
+    return () => {
+      removeHandleDMQueueInformation()
+    }
+  }, [])
+
+  return dmState
+}

--- a/src/frontend/hooks/useGetDownloadStatusText.ts
+++ b/src/frontend/hooks/useGetDownloadStatusText.ts
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 import { GameInfo } from 'common/types'
 import { getMessage } from 'frontend/screens/Library/constants'
 import { getCardStatus } from 'frontend/screens/Library/components/GameCard/constants'

--- a/src/frontend/hooks/useGetDownloadStatusText.ts
+++ b/src/frontend/hooks/useGetDownloadStatusText.ts
@@ -1,0 +1,41 @@
+import React, { useContext } from 'react'
+import { GameInfo } from 'common/types'
+import { getMessage } from 'frontend/screens/Library/constants'
+import { getCardStatus } from 'frontend/screens/Library/components/GameCard/constants'
+import { hasStatus } from './hasStatus'
+import { useTranslation } from 'react-i18next'
+import ContextProvider from 'frontend/state/ContextProvider'
+import { useGetDmState } from './useGetDmState'
+
+export function useGetDownloadStatusText(
+  appName: string,
+  gameInfo: GameInfo | undefined
+) {
+  const dmState = useGetDmState()
+  const { status } = hasStatus(appName, gameInfo)
+  const { t } = useTranslation('gamepage')
+  const { layout } = useContext(ContextProvider)
+  const { isInstalling } = getCardStatus(
+    status,
+    !!gameInfo?.is_installed,
+    layout
+  )
+
+  function getStatus() {
+    if (status === 'extracting') {
+      return 'extracting'
+    }
+    if (dmState === 'paused') {
+      return 'paused'
+    }
+    if (isInstalling) {
+      return 'installing'
+    }
+    if (gameInfo?.is_installed) {
+      return 'installed'
+    }
+    return 'installing'
+  }
+
+  return { statusText: getMessage(t, getStatus()), status: getStatus() }
+}

--- a/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
+++ b/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
@@ -92,8 +92,12 @@ const DownloadManagerItem = observer(({ element, current, state }: Props) => {
     platformToInstall
   } = params
 
-  const [gameInfo, setGameInfo] = useState(DmGameInfo);
-  const { status: gameProgressStatus = '' } = hasStatus(appName, DmGameInfo, (size || '0'));
+  const [gameInfo, setGameInfo] = useState(DmGameInfo)
+  const { status: gameProgressStatus = '' } = hasStatus(
+    appName,
+    DmGameInfo,
+    size || '0'
+  )
 
   useEffect(() => {
     const getNewInfo = async () => {
@@ -113,7 +117,7 @@ const DownloadManagerItem = observer(({ element, current, state }: Props) => {
       }
     }
     getNewInfo()
-  }, [element]);
+  }, [element])
 
   const {
     art_cover,
@@ -121,11 +125,11 @@ const DownloadManagerItem = observer(({ element, current, state }: Props) => {
     install: { is_dlc }
   } = gameInfo || {}
 
-  const [progress] = hasProgress(appName);
-  const { status } = element;
-  const finished = status === 'done';
-  const canceled = status === 'error' || (status === 'abort' && !current);
-  const isExtracting = gameProgressStatus === 'extracting';
+  const [progress] = hasProgress(appName)
+  const { status } = element
+  const finished = status === 'done'
+  const canceled = status === 'error' || (status === 'abort' && !current)
+  const isExtracting = gameProgressStatus === 'extracting'
 
   const goToGamePage = () => {
     if (is_dlc) {
@@ -181,7 +185,7 @@ const DownloadManagerItem = observer(({ element, current, state }: Props) => {
       return <PauseIcon className="pauseIcon" />
     }
 
-    return <></>;
+    return <></>
   }
 
   const getTime = () => {

--- a/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
+++ b/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
@@ -250,7 +250,7 @@ const DownloadManagerItem = observer(({ element, current, state }: Props) => {
           folderName={gameInfo.folder_name ? gameInfo.folder_name : ''}
           appName={appName}
           runner={runner}
-          status={status || ''}
+          status={status}
           progress={progress}
         />
       ) : null}

--- a/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
+++ b/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
@@ -28,6 +28,7 @@ import StopInstallationModal from 'frontend/components/UI/StopInstallationModal'
 import { observer } from 'mobx-react-lite'
 import libraryState from 'frontend/state/libraryState'
 import { NileInstallInfo } from 'common/types/nile'
+import { hasStatus } from 'frontend/hooks/hasStatus'
 
 type Props = {
   element?: DMQueueElement
@@ -91,7 +92,8 @@ const DownloadManagerItem = observer(({ element, current, state }: Props) => {
     platformToInstall
   } = params
 
-  const [gameInfo, setGameInfo] = useState(DmGameInfo)
+  const [gameInfo, setGameInfo] = useState(DmGameInfo);
+  const { status: gameProgressStatus = '' } = hasStatus(appName, DmGameInfo, (size || '0'));
 
   useEffect(() => {
     const getNewInfo = async () => {
@@ -111,7 +113,7 @@ const DownloadManagerItem = observer(({ element, current, state }: Props) => {
       }
     }
     getNewInfo()
-  }, [element])
+  }, [element]);
 
   const {
     art_cover,
@@ -119,10 +121,11 @@ const DownloadManagerItem = observer(({ element, current, state }: Props) => {
     install: { is_dlc }
   } = gameInfo || {}
 
-  const [progress] = hasProgress(appName)
-  const { status } = element
-  const finished = status === 'done'
-  const canceled = status === 'error' || (status === 'abort' && !current)
+  const [progress] = hasProgress(appName);
+  const { status } = element;
+  const finished = status === 'done';
+  const canceled = status === 'error' || (status === 'abort' && !current);
+  const isExtracting = gameProgressStatus === 'extracting';
 
   const goToGamePage = () => {
     if (is_dlc) {
@@ -176,9 +179,9 @@ const DownloadManagerItem = observer(({ element, current, state }: Props) => {
       return <PlayIcon className="playIcon" />
     } else if (state === 'running') {
       return <PauseIcon className="pauseIcon" />
-    } else {
-      return <></>
     }
+
+    return <></>;
   }
 
   const getTime = () => {
@@ -282,7 +285,7 @@ const DownloadManagerItem = observer(({ element, current, state }: Props) => {
           <SvgButton onClick={handleMainActionClick} title={mainIconTitle()}>
             {mainActionIcon()}
           </SvgButton>
-          {current && (
+          {current && !isExtracting && (
             <SvgButton
               onClick={handleSecondaryActionClick}
               title={secondaryIconTitle()}

--- a/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
+++ b/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
@@ -250,6 +250,7 @@ const DownloadManagerItem = observer(({ element, current, state }: Props) => {
           folderName={gameInfo.folder_name ? gameInfo.folder_name : ''}
           appName={appName}
           runner={runner}
+          status={status || ''}
           progress={progress}
         />
       ) : null}

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -625,8 +625,7 @@ export default observer(function GamePage(): JSX.Element | null {
                       isReparing ||
                       isMoving ||
                       isUninstalling ||
-                      notSupportedGame ||
-                      isExtracting
+                      notSupportedGame
                     }
                     autoFocus={true}
                     type={getButtonClass(is_installed)}
@@ -775,10 +774,6 @@ export default observer(function GamePage(): JSX.Element | null {
       return `${t('status.moving', 'Moving Installation, please wait')} ...`
     }
 
-    if (isExtracting) {
-      return `${t('status.extracting', 'Extracting files')}...`
-    }
-
     const currentProgress =
       getProgress(progress) >= 99
         ? ''
@@ -798,6 +793,10 @@ export default observer(function GamePage(): JSX.Element | null {
         return `${t('status.reparing')}: ${percent} [${bytes}]`
       }
       return `${t('status.updating')} ${currentProgress}`
+    }
+
+    if (isExtracting) {
+      return `${t('status.extracting')} ${currentProgress}`
     }
 
     if (!isUpdating && isInstalling) {
@@ -863,7 +862,7 @@ export default observer(function GamePage(): JSX.Element | null {
       return t('submenu.settings')
     }
     if (isExtracting) {
-      return t('status.extracting', 'Extracting files')
+      return t('status.extracting.cancel', 'Cancel Extraction')
     }
     if (isInstalling || isPreparing) {
       return t('button.queue.cancel', 'Cancel Download')
@@ -906,6 +905,11 @@ export default observer(function GamePage(): JSX.Element | null {
     if (isInstalling) {
       setShowStopInstallModal(true)
       return
+    }
+
+    if (isExtracting) {
+      storage.removeItem(appName)
+      return window.api.cancelExtraction(appName);
     }
 
     // open install dialog

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -909,7 +909,7 @@ export default observer(function GamePage(): JSX.Element | null {
 
     if (isExtracting) {
       storage.removeItem(appName)
-      return window.api.cancelExtraction(appName);
+      return window.api.cancelExtraction(appName)
     }
 
     // open install dialog

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -364,6 +364,7 @@ export default observer(function GamePage(): JSX.Element | null {
             folderName={gameInfo.folder_name ? gameInfo.folder_name : ''}
             appName={gameInfo.app_name}
             runner={gameInfo.runner}
+            status={status}
           />
         ) : null}
         {gameInfo.runner !== 'sideload' && showModal.show && (

--- a/src/frontend/screens/Library/components/GameCard/constants.ts
+++ b/src/frontend/screens/Library/components/GameCard/constants.ts
@@ -32,6 +32,7 @@ export function getCardStatus(
   const syncingSaves = status === 'syncing-saves'
   const isPaused = status === 'paused'
   const isPreparing = status === 'preparing'
+  const isExtracting = status === 'extracting'
 
   const haveStatus =
     isMoving ||
@@ -58,6 +59,7 @@ export function getCardStatus(
     isUpdating,
     isPaused,
     isPreparing,
+    isExtracting,
     haveStatus
   }
 }

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -54,12 +54,8 @@ const GameCard = ({
 
   const navigate = useNavigate()
 
-  const {
-    layout,
-    allTilesInColor,
-    showDialogModal,
-    setIsSettingsModalOpen
-  } = useContext(ContextProvider)
+  const { layout, allTilesInColor, showDialogModal, setIsSettingsModalOpen } =
+    useContext(ContextProvider)
 
   const {
     title,

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -106,7 +106,7 @@ const GameCard = ({
     notAvailable,
     isUpdating,
     isPaused,
-    isExtracting,
+    isExtracting
   } = getCardStatus(status, isInstalled, layout)
 
   const handleRemoveFromQueue = () => {

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -73,8 +73,8 @@ const GameCard = ({
     ...gameInstallInfo
   }
 
-  const { status, folder } = hasStatus(appName, gameInfo, size)
-  const { statusText: downloadStatusText, status: downloadStatus } =
+  const { status = '', folder } = hasStatus(appName, gameInfo, size)
+  const { statusText: downloadStatusText } =
     useGetDownloadStatusText(appName, gameInfo)
 
   useEffect(() => {
@@ -103,7 +103,8 @@ const GameCard = ({
     isPlaying,
     notAvailable,
     isUpdating,
-    isPaused
+    isPaused,
+    isExtracting,
   } = getCardStatus(status, isInstalled, layout)
 
   const handleRemoveFromQueue = () => {
@@ -293,6 +294,7 @@ const GameCard = ({
           appName={appName}
           runner={runner}
           folderName={gameInfo.folder_name ? gameInfo.folder_name : ''}
+          status={status}
         />
       ) : null}
       {showUninstallModal && (
@@ -337,9 +339,7 @@ const GameCard = ({
             window.api.resumeCurrentDownload()
           )}
           onPlayClick={handleClickStopBubbling(async () => mainAction(runner))}
-          onStopDownloadClick={handleClickStopBubbling(async () =>
-            setShowStopInstallModal(true)
-          )}
+          onStopDownloadClick={handleClickStopBubbling(async () => setShowStopInstallModal(true))}
           state={getState()}
           settingsItems={items.filter((val) => val.show).slice(0, 6)}
           showSettings={showSettings}

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -283,10 +283,6 @@ const GameCard = ({
 
   const { activeController } = useContext(ContextProvider)
 
-  if (downloadStatus === 'extracting') {
-    progress.percent = 100
-  }
-
   return (
     <>
       {showStopInstallModal ? (

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -106,6 +106,7 @@ const GameCard = ({
     notAvailable,
     isUpdating,
     isPaused,
+    isExtracting,
   } = getCardStatus(status, isInstalled, layout)
 
   const handleRemoveFromQueue = () => {
@@ -120,6 +121,9 @@ const GameCard = ({
     }
     if (isUninstalling) {
       return 'UNINSTALLING'
+    }
+    if (isExtracting) {
+      return 'EXTRACTING'
     }
     if (isQueued) {
       return 'QUEUED'
@@ -366,7 +370,7 @@ const GameCard = ({
   )
 
   async function mainAction(runner: Runner) {
-    if (isInstalling || isPaused) {
+    if (isInstalling || isExtracting || isPaused) {
       return setShowStopInstallModal(true)
     }
 

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -74,8 +74,10 @@ const GameCard = ({
   }
 
   const { status = '', folder } = hasStatus(appName, gameInfo, size)
-  const { statusText: downloadStatusText } =
-    useGetDownloadStatusText(appName, gameInfo)
+  const { statusText: downloadStatusText } = useGetDownloadStatusText(
+    appName,
+    gameInfo
+  )
 
   useEffect(() => {
     setIsLaunching(false)
@@ -104,7 +106,6 @@ const GameCard = ({
     notAvailable,
     isUpdating,
     isPaused,
-    isExtracting,
   } = getCardStatus(status, isInstalled, layout)
 
   const handleRemoveFromQueue = () => {
@@ -339,7 +340,9 @@ const GameCard = ({
             window.api.resumeCurrentDownload()
           )}
           onPlayClick={handleClickStopBubbling(async () => mainAction(runner))}
-          onStopDownloadClick={handleClickStopBubbling(async () => setShowStopInstallModal(true))}
+          onStopDownloadClick={handleClickStopBubbling(async () =>
+            setShowStopInstallModal(true)
+          )}
           state={getState()}
           settingsItems={items.filter((val) => val.show).slice(0, 6)}
           showSettings={showSettings}

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -1,8 +1,8 @@
 import './index.css'
 
-import React, { useContext, useState, useEffect } from 'react'
+import React, { useContext, useState, useEffect, useMemo } from 'react'
 
-import { GameInfo, Runner } from 'common/types'
+import { GameInfo, HiddenGame, Runner } from 'common/types'
 import { Link, useNavigate } from 'react-router-dom'
 
 import { getGameInfo, install, launch } from 'frontend/helpers'
@@ -23,9 +23,9 @@ import {
   SettingsButtons
 } from '@hyperplay/ui'
 import classNames from 'classnames'
+import { useGetDownloadStatusText } from 'frontend/hooks/useGetDownloadStatusText'
 import libraryState from 'frontend/state/libraryState'
 import DMQueueState from 'frontend/state/DMQueueState'
-import { useGetDownloadStatusText } from 'frontend/hooks/useGetDownloadStatusText'
 
 interface Card {
   buttonClick: () => void
@@ -54,8 +54,13 @@ const GameCard = ({
 
   const navigate = useNavigate()
 
-  const { layout, allTilesInColor, showDialogModal, setIsSettingsModalOpen } =
-    useContext(ContextProvider)
+  const {
+    layout,
+    hiddenGames,
+    allTilesInColor,
+    showDialogModal,
+    setIsSettingsModalOpen
+  } = useContext(ContextProvider)
 
   const {
     title,

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -1,8 +1,8 @@
 import './index.css'
 
-import React, { useContext, useState, useEffect, useMemo } from 'react'
+import React, { useContext, useState, useEffect } from 'react'
 
-import { GameInfo, HiddenGame, Runner } from 'common/types'
+import { GameInfo, Runner } from 'common/types'
 import { Link, useNavigate } from 'react-router-dom'
 
 import { getGameInfo, install, launch } from 'frontend/helpers'
@@ -56,7 +56,6 @@ const GameCard = ({
 
   const {
     layout,
-    hiddenGames,
     allTilesInColor,
     showDialogModal,
     setIsSettingsModalOpen
@@ -148,12 +147,7 @@ const GameCard = ({
     return 'NOT_INSTALLED'
   }
 
-  const isHiddenGame = useMemo(() => {
-    return !!hiddenGames.list.find(
-      (hiddenGame: HiddenGame) => hiddenGame.appName === appName
-    )
-  }, [hiddenGames, appName])
-
+  const isHiddenGame = libraryState.isGameHidden(appName)
   const isBrowserGame = installPlatform === 'Browser'
 
   const onUninstallClick = function () {

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -106,12 +106,12 @@ function getDefaultInstallPath() {
  * @return {number} - Total size uncompressed estimated based on platform (windows: zip, winrar 60-80%, mac: zip 70-90%, linux: 60-80% )
  */
 const estimateUncompressedSize = (platform: string, compressedSize: number) => {
-    const baseEstimate = compressedSize * 2;
-    const gapPercentage = platform === 'osx' ? 0.05 : 0.1;
+  const baseEstimate = compressedSize * 2
+  const gapPercentage = platform === 'osx' ? 0.05 : 0.1
 
-    const gap = baseEstimate * gapPercentage;
-  
-    return baseEstimate + gap;
+  const gap = baseEstimate * gapPercentage
+
+  return baseEstimate + gap
 }
 
 export default function DownloadDialog({
@@ -172,8 +172,11 @@ export default function DownloadDialog({
 
   const { i18n, t } = useTranslation('gamepage')
   const { t: tr } = useTranslation()
-  
-  const uncompressedSize = estimateUncompressedSize(platformToInstall, gameInstallInfo?.manifest?.disk_size || 0)
+
+  const uncompressedSize = estimateUncompressedSize(
+    platformToInstall,
+    gameInstallInfo?.manifest?.disk_size || 0
+  )
 
   const haveSDL = sdls.length > 0
 
@@ -315,12 +318,12 @@ export default function DownloadDialog({
 
   useEffect(() => {
     const getSpace = async () => {
-      const { message, free, validPath } = await window.api.checkDiskSpace(installPath)
+      const { message, free, validPath } = await window.api.checkDiskSpace(
+        installPath
+      )
       if (gameInstallInfo?.manifest?.disk_size) {
         let notEnoughDiskSpace = free < uncompressedSize
-        let spaceLeftAfter = size(
-          free - Number(uncompressedSize)
-        )
+        let spaceLeftAfter = size(free - Number(uncompressedSize))
         if (previousProgress.folder === installPath) {
           const progress = 100 - getProgress(previousProgress)
           notEnoughDiskSpace =
@@ -363,8 +366,7 @@ export default function DownloadDialog({
   }
 
   const installSize =
-    gameInstallInfo?.manifest?.disk_size !== undefined &&
-    size(uncompressedSize)
+    gameInstallInfo?.manifest?.disk_size !== undefined && size(uncompressedSize)
 
   const getLanguageName = useMemo(() => {
     return (language: string) => {

--- a/src/frontend/screens/Library/constants.ts
+++ b/src/frontend/screens/Library/constants.ts
@@ -40,3 +40,19 @@ export function translateChannelName(
       return channelNameEnglish
   }
 }
+
+export function getMessage(
+  t: TFunction<'translation'>,
+  status: 'extracting' | 'paused' | 'installing' | 'installed'
+): string | undefined {
+  switch (status) {
+    case 'extracting':
+      return t('hyperplay.gamecard.extracting', 'Extracting...')
+    case 'paused':
+      return t('hyperplay.gamecard.paused', 'Paused')
+    case 'installing':
+      return t('hyperplay.gamecard.installing', 'Downloading...')
+    case 'installed':
+      return t('hyperplay.gamecard.installed', 'Ready to play')
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1614,24 +1614,12 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.0.tgz#76467a94aa888aeb22aafa43eb6ff889df3a5a7f"
   integrity sha512-rBevIsj2nclStJ7AxTdfsa3ovHb1H+qApwrxcTVo+NNdeJiB9V75hsKfrkG5AwNcRUNxrPPiScGYCNmLMoh8pg==
 
-"@fortawesome/fontawesome-common-types@6.4.2":
-  version "6.4.2"
-  resolved "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/6.4.2/fontawesome-common-types-6.4.2.tgz#1766039cad33f8ad87f9467b98e0d18fbc8f01c5"
-  integrity sha512-1DgP7f+XQIJbLFCTX1V2QnxVmpLdKdzzo2k8EmvDOePfchaIGQ9eCHj2up3/jNEbZuBqel5OxiaOJf37TWauRA==
-
 "@fortawesome/fontawesome-svg-core@^6.1.1":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.2.0.tgz#11856eaf4dd1d865c442ddea1eed8ee855186ba2"
   integrity sha512-Cf2mAAeMWFMzpLC7Y9H1I4o3wEU+XovVJhTiNG8ZNgSQj53yl7OCJaS80K4YjrABWZzbAHVaoHE1dVJ27AAYXw==
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.2.0"
-
-"@fortawesome/fontawesome-svg-core@^6.4.0":
-  version "6.4.2"
-  resolved "https://npm.fontawesome.com/@fortawesome/fontawesome-svg-core/-/6.4.2/fontawesome-svg-core-6.4.2.tgz#37f4507d5ec645c8b50df6db14eced32a6f9be09"
-  integrity sha512-gjYDSKv3TrM2sLTOKBc5rH9ckje8Wrwgx1CxAPbN5N3Fm4prfi7NsJVWd1jklp7i5uSCVwhZS5qlhMXqLrpAIg==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "6.4.2"
 
 "@fortawesome/free-brands-svg-icons@^6.1.1":
   version "6.2.0"
@@ -1647,13 +1635,6 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.2.0"
 
-"@fortawesome/free-regular-svg-icons@^6.4.0":
-  version "6.4.2"
-  resolved "https://npm.fontawesome.com/@fortawesome/free-regular-svg-icons/-/6.4.2/free-regular-svg-icons-6.4.2.tgz#aee79ed76ce5dd04931352f9d83700761b8b1b25"
-  integrity sha512-0+sIUWnkgTVVXVAPQmW4vxb9ZTHv0WstOa3rBx9iPxrrrDH6bNLsDYuwXF9b6fGm+iR7DKQvQshUH/FJm3ed9Q==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "6.4.2"
-
 "@fortawesome/free-solid-svg-icons@^6.1.1":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.2.0.tgz#8dcde48109354fd7a5ece8ea48d678bb91d4b5f0"
@@ -1661,24 +1642,10 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.2.0"
 
-"@fortawesome/free-solid-svg-icons@^6.4.0":
-  version "6.4.2"
-  resolved "https://npm.fontawesome.com/@fortawesome/free-solid-svg-icons/-/6.4.2/free-solid-svg-icons-6.4.2.tgz#33a02c4cb6aa28abea7bc082a9626b7922099df4"
-  integrity sha512-sYwXurXUEQS32fZz9hVCUUv/xu49PEJEyUOsA51l6PU/qVgfbTb2glsTEaJngVVT8VqBATRIdh7XVgV1JF1LkA==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "6.4.2"
-
 "@fortawesome/react-fontawesome@^0.1.18":
   version "0.1.19"
   resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.19.tgz#2b36917578596f31934e71f92b7cf9c425fd06e4"
   integrity sha512-Hyb+lB8T18cvLNX0S3llz7PcSOAJMLwiVKBuuzwM/nI5uoBw+gQjnf9il0fR1C3DKOI5Kc79pkJ4/xB0Uw9aFQ==
-  dependencies:
-    prop-types "^15.8.1"
-
-"@fortawesome/react-fontawesome@^0.2.0":
-  version "0.2.0"
-  resolved "https://npm.fontawesome.com/@fortawesome/react-fontawesome/-/0.2.0/react-fontawesome-0.2.0.tgz#d90dd8a9211830b4e3c08e94b63a0ba7291ddcf4"
-  integrity sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==
   dependencies:
     prop-types "^15.8.1"
 
@@ -1700,13 +1667,6 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
-
-"@hyperplay/chains@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@hyperplay/chains/-/chains-0.0.2.tgz#329aabdd30d5f1c25233fcb342840624fff235d1"
-  integrity sha512-yex3/IOnmxtM1N0uU20cceVKUDAjAGFO0LKNxH45Nn+bbOaVgXJCsXqEk3NfVLGk08X71fSDzRCcX2UCSUwEmA==
-  dependencies:
-    axios "^1.4.0"
 
 "@hyperplay/ui@^0.1.27":
   version "0.1.28"
@@ -4655,15 +4615,6 @@ axios@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
   integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
-  dependencies:
-    follow-redirects "^1.15.0"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
-
-axios@^1.4.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.5.1.tgz#11fbaa11fc35f431193a9564109c88c1f27b585f"
-  integrity sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==
   dependencies:
     follow-redirects "^1.15.0"
     form-data "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1614,12 +1614,24 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.0.tgz#76467a94aa888aeb22aafa43eb6ff889df3a5a7f"
   integrity sha512-rBevIsj2nclStJ7AxTdfsa3ovHb1H+qApwrxcTVo+NNdeJiB9V75hsKfrkG5AwNcRUNxrPPiScGYCNmLMoh8pg==
 
+"@fortawesome/fontawesome-common-types@6.4.2":
+  version "6.4.2"
+  resolved "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/6.4.2/fontawesome-common-types-6.4.2.tgz#1766039cad33f8ad87f9467b98e0d18fbc8f01c5"
+  integrity sha512-1DgP7f+XQIJbLFCTX1V2QnxVmpLdKdzzo2k8EmvDOePfchaIGQ9eCHj2up3/jNEbZuBqel5OxiaOJf37TWauRA==
+
 "@fortawesome/fontawesome-svg-core@^6.1.1":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.2.0.tgz#11856eaf4dd1d865c442ddea1eed8ee855186ba2"
   integrity sha512-Cf2mAAeMWFMzpLC7Y9H1I4o3wEU+XovVJhTiNG8ZNgSQj53yl7OCJaS80K4YjrABWZzbAHVaoHE1dVJ27AAYXw==
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.2.0"
+
+"@fortawesome/fontawesome-svg-core@^6.4.0":
+  version "6.4.2"
+  resolved "https://npm.fontawesome.com/@fortawesome/fontawesome-svg-core/-/6.4.2/fontawesome-svg-core-6.4.2.tgz#37f4507d5ec645c8b50df6db14eced32a6f9be09"
+  integrity sha512-gjYDSKv3TrM2sLTOKBc5rH9ckje8Wrwgx1CxAPbN5N3Fm4prfi7NsJVWd1jklp7i5uSCVwhZS5qlhMXqLrpAIg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.4.2"
 
 "@fortawesome/free-brands-svg-icons@^6.1.1":
   version "6.2.0"
@@ -1635,6 +1647,13 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.2.0"
 
+"@fortawesome/free-regular-svg-icons@^6.4.0":
+  version "6.4.2"
+  resolved "https://npm.fontawesome.com/@fortawesome/free-regular-svg-icons/-/6.4.2/free-regular-svg-icons-6.4.2.tgz#aee79ed76ce5dd04931352f9d83700761b8b1b25"
+  integrity sha512-0+sIUWnkgTVVXVAPQmW4vxb9ZTHv0WstOa3rBx9iPxrrrDH6bNLsDYuwXF9b6fGm+iR7DKQvQshUH/FJm3ed9Q==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.4.2"
+
 "@fortawesome/free-solid-svg-icons@^6.1.1":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.2.0.tgz#8dcde48109354fd7a5ece8ea48d678bb91d4b5f0"
@@ -1642,10 +1661,24 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.2.0"
 
+"@fortawesome/free-solid-svg-icons@^6.4.0":
+  version "6.4.2"
+  resolved "https://npm.fontawesome.com/@fortawesome/free-solid-svg-icons/-/6.4.2/free-solid-svg-icons-6.4.2.tgz#33a02c4cb6aa28abea7bc082a9626b7922099df4"
+  integrity sha512-sYwXurXUEQS32fZz9hVCUUv/xu49PEJEyUOsA51l6PU/qVgfbTb2glsTEaJngVVT8VqBATRIdh7XVgV1JF1LkA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.4.2"
+
 "@fortawesome/react-fontawesome@^0.1.18":
   version "0.1.19"
   resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.19.tgz#2b36917578596f31934e71f92b7cf9c425fd06e4"
   integrity sha512-Hyb+lB8T18cvLNX0S3llz7PcSOAJMLwiVKBuuzwM/nI5uoBw+gQjnf9il0fR1C3DKOI5Kc79pkJ4/xB0Uw9aFQ==
+  dependencies:
+    prop-types "^15.8.1"
+
+"@fortawesome/react-fontawesome@^0.2.0":
+  version "0.2.0"
+  resolved "https://npm.fontawesome.com/@fortawesome/react-fontawesome/-/0.2.0/react-fontawesome-0.2.0.tgz#d90dd8a9211830b4e3c08e94b63a0ba7291ddcf4"
+  integrity sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==
   dependencies:
     prop-types "^15.8.1"
 
@@ -1667,6 +1700,18 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
+
+"@hyperplay/chains@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@hyperplay/chains/-/chains-0.0.2.tgz#329aabdd30d5f1c25233fcb342840624fff235d1"
+  integrity sha512-yex3/IOnmxtM1N0uU20cceVKUDAjAGFO0LKNxH45Nn+bbOaVgXJCsXqEk3NfVLGk08X71fSDzRCcX2UCSUwEmA==
+  dependencies:
+    axios "^1.4.0"
+
+"@hyperplay/ui@^0.1.27":
+  version "0.1.28"
+  resolved "https://registry.yarnpkg.com/@hyperplay/ui/-/ui-0.1.28.tgz#6a9af1dcf5dfd6df47edbe68c2d2ff99c5fac163"
+  integrity sha512-jBiBu3CV6sUFrr0koHm4a4R45KKDoc+HlGL5KingcM9OsXRyrrAXOOMMIRIEojW/y9Zxup0pkZKNO6y7bAGfyA==
 
 "@ioredis/commands@^1.1.1":
   version "1.2.0"
@@ -4610,6 +4655,15 @@ axios@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
   integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
+axios@^1.4.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.5.1.tgz#11fbaa11fc35f431193a9564109c88c1f27b585f"
+  integrity sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==
   dependencies:
     follow-redirects "^1.15.0"
     form-data "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1668,11 +1668,6 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@hyperplay/ui@^0.1.27":
-  version "0.1.27"
-  resolved "https://registry.yarnpkg.com/@hyperplay/ui/-/ui-0.1.27.tgz#f7bd511ca6cbd946c117fd1ed59446e988aff726"
-  integrity sha512-rCkFP2L/+P5IhlMsaEOCxedgOjQ9Mk+8YZ2GUjQeeNpyMezQLMFRVOzHP59EEc0BjX2uE2zvEr7H15vMifCSDQ==
-
 "@ioredis/commands@^1.1.1":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.2.0.tgz#6d61b3097470af1fdbbe622795b8921d42018e11"


### PR DESCRIPTION
WIP

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)

---

## 🐛 Issue Addressed

**Linked Issue:** [Install modal does not display extracting](https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/issues/455) - PR Main issue
**Linked Issue:** [Disk space check does not account for extraction space](https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/issues/614)

---

## ✅  Other Fixed Issues

-  Progress on Download does not start from 0, generally was started either from previous queued progress if it was canceled earlier
- Disk Space is another issue mentioned by @nyghtstalker, and fixed with suggest of @flavioislima. Currently, we are utilizing a basic function to estimate disk space. Typically, the estimated size is doubled and then increased by 0.05-0.01%, depending on whether it is being compressed on a Mac (higher percentage) or on Windows and other operating systems.
- Upon relaunch the download modal appears again even though there is nothing downloading. This should be fixed, although @nyghtstalker, please make sure to check it out as soon this PR read for review

---

## 🚀 Props API Update for Components

- Updated GameState to handle the new status of `inExtraction`
- Updated `DownloadToast` with a new `downloadStatus` type: 'inExtraction'

## ☕ New PCI Handlers

- cancelExtraction | window.api.cancelExtraction(appName: string). This method allows you to cancel an extraction, generally would require an extraction in progress.

---

## 📌 PR Blocked From Issue Below

[HyperPlay-Gaming/hyperplay-ui#101](https://github.com/HyperPlay-Gaming/hyperplay-ui/pull/101)

---

## 🗺️ Approach Taken

Our aim is to start using classes because we have a lot of code that is intertwined and makes debugging, fixing, or enhancing the code time-consuming. For instance, we have developed an `ExtractZipService` class that handles zip extraction-related functionalities, including the decompressed total bytes for later use. Our approach enables us to test the class independently, providing us with a better guarantee that everything is working as expected. Additionally, we always apply the SOC Principle, which helps us avoid days of debugging. 🙌 

---

## 🛠️ Testing Steps

Before diving in, ensure you have access to both `hyperplay-ui` and `hyplerplay-store` repositories.

1. Navigate to the feature branch:
```bash
git fetch && git checkout 455-update-game-card-and-download-toast-for-extraction && git pull
```
2. If you haven't already, clone the `hyperplay-ui`:
```bash
git clone https://github.com/HyperPlay-Gaming/hyperplay-ui.git
```
3. Switch to the relevant branch in `hyperplay-ui`:
```bash
git fetch && git 455-update-game-card-and-download-toast-for-extraction && git pull
```
4. Link `hyperplay-ui` to `hyperplay-desktop-client`:
```bash
yarn add path/to/your/hyperplay-ui
```
5. Fire up the development server:
```bash
yarn start
```
6. Next head to Store > Find `Megaweapon` > Add to Library
7. Next head to your library
8. Tap Download Icon
9. Install Model will show, which generally you would be already able to see the uncompressed size (`estimated`)
10. Tap Install
11. Wait until the extraction process
12. Wait until it does install

---

### ⚠️ Review Tests

Please make sure to test all the following, please feel free to edit the PR readme in case there are more ways we should test

**Pages**
- [ ] Check on Library
- [ ] Check on game page
- [ ] Check on the Download Manager page
- [ ] I don't know how we can test it yet, but try to install it through the store

**Toast, Download Bar on Game Card, Game Actions on Download Manager, Buttons on Game Page (Cancel Extraction, Cancel Download, etc)** 
- [ ] Pause Download
- [ ] Pause Download & Cancel
- [ ] Pause Download & Cancel & Reinitiate 
- [ ] Resume Download
- [ ] Resume Download & Cancel
- [ ] Resume Download & Cancel & Reinitiate the download 
- [ ] Cancel Extraction 
- [ ] Cancel Extraction & Reinitiate the download

**UI**
- [ ] Download Toast must have Pause or Resume Button, Cancel Button
- [ ] Download Bar Game Card must have Pause or Resume Button, Cancel Button
- [ ] Extraction Toast must only Cancel Button
- [ ] Extraction Bar Game Card must have Pause or Resume Button, Cancel Button
- [ ] Extraction Game Page must have Cancel Download Button
- [ ] Extraction Game Page must only Cancel Extraction Button

---

## 📣 Important Note

This fix pinpoints where pause, resume are generally controlled by a status on `hyperplay-ui` lib, which we had to add. Once we're all aligned, let's ensure to 
- We merge [HyperPlay-Gaming/hyperplay-ui#101](https://github.com/HyperPlay-Gaming/hyperplay-ui/pull/101). 
- Quick update to the `package.json` of `hyperplay-ui` will be needed, with the latest update
- Without the merge of [HyperPlay-Gaming/hyperplay-ui#101](https://github.com/HyperPlay-Gaming/hyperplay-ui/pull/101) then the Code Check will fail, due of the interface.
