### PR TITLE
Reopen auth modal on app reload after import

### DIFF
--- a/src/backend/api/misc.ts
+++ b/src/backend/api/misc.ts
@@ -198,3 +198,7 @@ export const handleQaModeActivated = (
     ipcRenderer.removeListener('qaModeActive', onChange)
   }
 }
+
+export const openAuthModalIfAppReloads = () => {
+  ipcRenderer.send('openAuthModalIfAppReloads')
+}

--- a/src/backend/constants.ts
+++ b/src/backend/constants.ts
@@ -232,7 +232,8 @@ export function createNecessaryFolders() {
 }
 
 const onboardLocalStore = new TypeCheckedStoreBackend('onboardingStore', {
-  cwd: 'store'
+  cwd: 'store',
+  name: 'onboarding-store'
 })
 
 export {

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -106,7 +106,8 @@ import {
   fixAsarPath,
   twitterLink,
   eventsToCloseMetaMaskPopupOn,
-  setQaToken
+  setQaToken,
+  onboardLocalStore
 } from './constants'
 import { handleProtocol } from './protocol'
 import {
@@ -1952,4 +1953,8 @@ ipcMain.on('openGameInEpicStore', async (_e, url) => {
 ipcMain.on('setQaToken', (_e, qaToken) => {
   setQaToken(qaToken)
   if (qaToken.length > 0) sendFrontendMessage('qaModeActive')
+})
+
+ipcMain.on('openAuthModalIfAppReloads', () => {
+  onboardLocalStore.set('openAuthModalIfAppReloads', true)
 })

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -71,6 +71,7 @@ interface HyperPlaySyncIPCFunctions {
   ignoreExitToTray: () => void
   setQaToken: (qaToken: string) => void
   removeFromLibrary: (appName: string) => void
+  openAuthModalIfAppReloads: () => void
 }
 
 interface SyncIPCFunctions extends HyperPlaySyncIPCFunctions {

--- a/src/common/types/electron_store.ts
+++ b/src/common/types/electron_store.ts
@@ -97,6 +97,7 @@ export interface StoreStructure {
   onboardingStore: {
     completedEarlyAccess: boolean
     completedDataPrivacy: boolean
+    openAuthModalIfAppReloads: boolean
   }
   hpLibraryStore: {
     [key: string]: GameInfo[]

--- a/src/frontend/components/UI/AuthModal/index.tsx
+++ b/src/frontend/components/UI/AuthModal/index.tsx
@@ -33,6 +33,7 @@ const AuthModal = () => {
     const currentProvider = await window.api.getConnectedProvider()
 
     if (currentProvider === 'Unconnected') {
+      window.api.openAuthModalIfAppReloads()
       onboardingStore.openOnboarding()
       authState.setPendingSignatureRequest(true)
       return
@@ -101,7 +102,7 @@ const AuthModal = () => {
 
   return (
     <ModalAnimation
-      isOpen={authState.isSingInModalOpen && authState.isQaModeActive}
+      isOpen={authState.isSignInModalOpen}
       onClose={() => authState.closeSignInModal()}
     >
       <webview

--- a/src/frontend/state/authState.ts
+++ b/src/frontend/state/authState.ts
@@ -1,21 +1,26 @@
+import { onboardingStore } from 'frontend/helpers/electronStores'
 import { makeAutoObservable } from 'mobx'
 
 class AuthState {
   private qaModeActive = false
-  private singInModalOpen = true
+  private signInModalOpen = false
   private signedIn = false
   private pendingSignatureRequest = false
 
   constructor() {
     makeAutoObservable(this)
+    this.signInModalOpen = onboardingStore.get(
+      'openAuthModalIfAppReloads',
+      false
+    )
   }
 
   get hasPendingSignatureRequest() {
     return this.pendingSignatureRequest
   }
 
-  get isSingInModalOpen() {
-    return this.singInModalOpen
+  get isSignInModalOpen() {
+    return this.signInModalOpen
   }
 
   get isSignedIn() {
@@ -27,11 +32,11 @@ class AuthState {
   }
 
   openSignInModal() {
-    this.singInModalOpen = true
+    this.signInModalOpen = true
   }
 
   closeSignInModal() {
-    this.singInModalOpen = false
+    this.signInModalOpen = false
   }
 
   activateQaMode() {


### PR DESCRIPTION
After import, HyperPlay reloads. This reopens the Auth Modal if the user was in the middle of the auth flow

We still need to handle setting `openAuthModalIfAppReloads` to false after connection or if the auth flow is abandoned by the user

@eliobricenov 

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
