### PR TITLE
[FIX] Sideloaded apps not showing after restart

### DIFF
--- a/src/frontend/state/libraryState.ts
+++ b/src/frontend/state/libraryState.ts
@@ -150,6 +150,8 @@ class LibraryState {
       this.refreshAmazonLibrary()
     }
 
+    this.refreshSideloadedLibrary()
+
     this.hyperPlayLibrary = hyperPlayLibraryStore.get('games', [])
     this.hiddenGames.list = configStore.get('games.hidden', [])
 


### PR DESCRIPTION
Fix #599 

## How to Test

1. On the library, click on Add Game
2. Select Browser as platform
3. Add Xcloud to the title
4. For the URL add `https://xbox.com/play`
5. Click on Finish
6. Restart HyperPlay
7. The Added App should still show on the library

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
