### PR TITLE
[CI-FIX] Fix Windows Workflow GH Action

### DIFF
--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -91,33 +91,10 @@ jobs:
           $latestYml.files[0].size = $size
           $latestYml | ConvertTo-Yaml | Set-Content -Path signed/latest.yml
 
-      - name: Get release
-        id: get_release
-        uses: bruceadams/get-release@v1.3.2
-
-      - name: Get artifact name
-        id: get_artifact_name
-        run: |
-          echo "::set-output name=artifact_name::$(Get-ChildItem -Path signed -Filter "HyperPlay*.exe" | Select-Object -ExpandProperty Name)"
-
-      - name: Upload release asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+      - name: Create Release
+        uses: ncipollo/release-action@v1.13.0
         with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: signed/${{ steps.get_artifact_name.outputs.artifact_name }}
-          asset_name: ${{ steps.get_artifact_name.outputs.artifact_name }}
-          asset_content_type: application/octet-stream
-
-      - name: Upload release asset
-        id: upload-latest-yml
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: signed/latest.yml
-          asset_name: latest.yml
-          asset_content_type: application/octet-stream
+          token: ${{ secrets.WORKFLOW_TOKEN }}
+          draft: true
+          allowUpdates: true
+          artifacts: 'signed/latest.yml,signed/HyperPlay*.exe,dist/*.blockmap'


### PR DESCRIPTION
Replace GetRelease action with [ReleaseAction](https://github.com/marketplace/actions/create-release) to fix 404 while getting the current release.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
