### PR TITLE
[Tech] Replace HP colored logo with optimized version

### DIFF
--- a/src/frontend/assets/hyperplay/index.tsx
+++ b/src/frontend/assets/hyperplay/index.tsx
@@ -1,6 +1,5 @@
 export { ReactComponent as BackArrow } from './back_arrow.svg'
 export { ReactComponent as CloseX } from './close_x.svg'
-export { ReactComponent as HyperPlayLogo } from './hyperplay_logo.svg'
 export { ReactComponent as HyperPlayLogoGreen } from './hyperplay_logo_green.svg'
 export { ReactComponent as HyperPlayLogoRed } from './hyperplay_logo_red.svg'
 export { ReactComponent as HyperPlayLogoWhite } from './hyperplay_logo_white.svg'

--- a/src/frontend/screens/Login/index.tsx
+++ b/src/frontend/screens/Login/index.tsx
@@ -6,14 +6,13 @@ import { useNavigate } from 'react-router'
 
 import { ReactComponent as EpicLogo } from 'frontend/assets/epic-logo.svg'
 import { ReactComponent as GOGLogo } from 'frontend/assets/gog-logo.svg'
-import { ReactComponent as HyperPlayLogo } from 'frontend/assets/hyperplay/hyperplay_logo.svg'
 import { ReactComponent as AmazonLogo } from 'frontend/assets/amazon-logo.svg'
 
 import { LanguageSelector, UpdateComponent } from '../../components/UI'
 import { FlagPosition } from '../../components/UI/LanguageSelector'
 import SIDLogin from './components/SIDLogin'
 import ContextProvider from '../../state/ContextProvider'
-import { Background } from '@hyperplay/ui'
+import { Background, Images } from '@hyperplay/ui'
 import libraryState from 'frontend/state/libraryState'
 import storeAuthState from 'frontend/state/storeAuthState'
 import { ENABLE_AMAZON_STORE } from 'frontend/constants'
@@ -82,7 +81,7 @@ export default React.memo(function NewLogin() {
       <div className="loginContentWrapper">
         <div className="runnerList">
           <div className="runnerHeader">
-            <HyperPlayLogo className="runnerHeaderIcon" />
+            <Images.HyperPlayLogoColored className="runnerHeaderIcon" />
             <div className="runnerHeaderText">
               <h1 className="title">HyperPlay</h1>
               <h2 className="subtitle">Games Launcher</h2>

--- a/src/frontend/screens/Onboarding/analytics/index.tsx
+++ b/src/frontend/screens/Onboarding/analytics/index.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import { ONBOARDING_SCREEN } from '../types'
 import { t } from 'i18next'
-import { HyperPlayLogo } from 'frontend/assets/hyperplay'
-import { Button } from '@hyperplay/ui'
+import { Button, Images } from '@hyperplay/ui'
 import AnalyticsStyle from './index.module.scss'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheck, faX } from '@fortawesome/free-solid-svg-icons'
 import { IconProp } from '@fortawesome/fontawesome-svg-core'
 import { onboardingStore } from 'frontend/helpers/electronStores'
 import { MetricsOptInStatus } from 'common/types'
+import OnboardingStyles from '../index.module.scss'
 
 interface BulletPointProps {
   icon: IconProp
@@ -65,7 +65,7 @@ interface AnalyticsProps {
 const Analytics: React.FC<AnalyticsProps> = function (props) {
   return (
     <>
-      <HyperPlayLogo />
+      <Images.HyperPlayLogoColored className={OnboardingStyles.hpLogo} />
       <h5>
         {t(
           'hyperplay.onboarding.analytics.title',

--- a/src/frontend/screens/Onboarding/index.module.scss
+++ b/src/frontend/screens/Onboarding/index.module.scss
@@ -45,3 +45,7 @@
   backdrop-filter: blur(2px);
   z-index: 2100;
 }
+
+.hpLogo {
+  max-width: 36px;
+}

--- a/src/frontend/screens/Onboarding/walletSelection/index.module.scss
+++ b/src/frontend/screens/Onboarding/walletSelection/index.module.scss
@@ -49,7 +49,3 @@
   flex-direction: column;
   height: 100%;
 }
-
-.hpLogo {
-  max-width: 36px;
-}

--- a/src/frontend/screens/Onboarding/walletSelection/index.module.scss
+++ b/src/frontend/screens/Onboarding/walletSelection/index.module.scss
@@ -49,3 +49,7 @@
   flex-direction: column;
   height: 100%;
 }
+
+.hpLogo {
+  max-width: 36px;
+}

--- a/src/frontend/screens/Onboarding/walletSelection/index.tsx
+++ b/src/frontend/screens/Onboarding/walletSelection/index.tsx
@@ -8,7 +8,8 @@ import React, {
 import WalletOption from '../components/walletOption'
 import { PROVIDERS } from 'common/types/proxy-types'
 // import './index.css'
-import { MMTransparent, WCBlue, HyperPlayLogo } from 'frontend/assets/hyperplay'
+import { MMTransparent, WCBlue } from 'frontend/assets/hyperplay'
+import { Images } from '@hyperplay/ui'
 import { t } from 'i18next'
 import WalletSelectionStyles from './index.module.scss'
 import WalletInfoScreen from './screens/info'
@@ -252,7 +253,7 @@ const WalletSelection: React.FC<WalletSelectionProps> = function (props) {
   return (
     <div className={WalletSelectionStyles.welcomeContainer}>
       <div className={WalletSelectionStyles.walletOptionsSection}>
-        <HyperPlayLogo />
+        <Images.HyperPlayLogoColored className={WalletSelectionStyles.hpLogo} />
         <div
           className={`title ${WalletSelectionStyles.walletConnectionsTitle}`}
         >

--- a/src/frontend/screens/Onboarding/walletSelection/index.tsx
+++ b/src/frontend/screens/Onboarding/walletSelection/index.tsx
@@ -12,6 +12,7 @@ import { MMTransparent, WCBlue } from 'frontend/assets/hyperplay'
 import { Images } from '@hyperplay/ui'
 import { t } from 'i18next'
 import WalletSelectionStyles from './index.module.scss'
+import OnboardingStyles from '../index.module.scss'
 import WalletInfoScreen from './screens/info'
 import WalletScanScreen from './screens/scan'
 import WalletImportScreen from './screens/import'
@@ -253,7 +254,7 @@ const WalletSelection: React.FC<WalletSelectionProps> = function (props) {
   return (
     <div className={WalletSelectionStyles.welcomeContainer}>
       <div className={WalletSelectionStyles.walletOptionsSection}>
-        <Images.HyperPlayLogoColored className={WalletSelectionStyles.hpLogo} />
+        <Images.HyperPlayLogoColored className={OnboardingStyles.hpLogo} />
         <div
           className={`title ${WalletSelectionStyles.walletConnectionsTitle}`}
         >

--- a/src/frontend/screens/Onboarding/welcome/index.tsx
+++ b/src/frontend/screens/Onboarding/welcome/index.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import { ONBOARDING_SCREEN } from '../types'
 import { t } from 'i18next'
-import { Button } from '@hyperplay/ui'
-import { HyperPlayLogo } from 'frontend/assets/hyperplay'
+import { Button, Images } from '@hyperplay/ui'
 import { LanguageSelector } from 'frontend/components/UI'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faArrowRight } from '@fortawesome/free-solid-svg-icons'
 import { FlagPosition } from 'frontend/components/UI/LanguageSelector'
 import { onboardingStore } from 'frontend/helpers/electronStores'
 import WelcomeStyles from './index.module.scss'
+import OnboardingStyles from '../index.module.scss'
 
 interface WelcomeProps {
   setScreen: React.Dispatch<React.SetStateAction<ONBOARDING_SCREEN>>
@@ -17,7 +17,7 @@ interface WelcomeProps {
 const Welcome: React.FC<WelcomeProps> = function (props) {
   return (
     <>
-      <HyperPlayLogo />
+      <Images.HyperPlayLogoColored className={OnboardingStyles.hpLogo} />
       <h5>
         {t(
           'hyperplay.onboarding.welcome.title',


### PR DESCRIPTION
Old logo was ~8KB and took >20ms to render. The new logo is ~0.8KB

HP UI logo is identical visually as well (bottom is from hp ui, top is the 8KB deleted one)
![image](https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/assets/27568879/8f603955-b1de-4f76-92fc-69e9375c00ba)
