### PR TITLE
[FEAT] Add feature flag for Amazon Store integration

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -33,10 +33,12 @@ import AuthModal from './components/UI/AuthModal'
 import EmailVerifiedModal from './components/UI/EmailVerifiedModal'
 import { WalletOnboardCloseReason } from 'common/types'
 import { DeviceStateController } from './state/DeviceState'
-import { ENABLE_AMAZON_STORE } from './constants'
+import { useFlags } from 'launchdarkly-react-client-sdk'
 
 function App() {
   const { sidebarCollapsed, isSettingsModalOpen } = useContext(ContextProvider)
+  const flags = useFlags()
+  const ENABLE_AMAZON_STORE = flags.amazonStore
 
   return (
     <div className={classNames('App', { collapsed: sidebarCollapsed })}>

--- a/src/frontend/components/UI/TopNavBar/index.tsx
+++ b/src/frontend/components/UI/TopNavBar/index.tsx
@@ -13,14 +13,16 @@ import {
   EPIC_STORE_URL,
   GOG_STORE_URL,
   AMAZON_STORE,
-  HYPERPLAY_STORE_URL,
-  ENABLE_AMAZON_STORE
+  HYPERPLAY_STORE_URL
 } from 'frontend/constants'
 import webviewNavigationStore from 'frontend/store/WebviewNavigationStore'
 import { extractMainDomain } from '../../../helpers/extract-main-domain'
+import { useFlags } from 'launchdarkly-react-client-sdk'
 
 const TopNavBar = observer(() => {
   const { t } = useTranslation()
+  const flags = useFlags()
+  const ENABLE_AMAZON_STORE = flags.amazonStore
 
   const { showMetaMaskBrowserSidebarLinks } = useContext(ContextProvider)
   const [badgeText, setBadgeText] = useState('0')

--- a/src/frontend/constants.ts
+++ b/src/frontend/constants.ts
@@ -6,5 +6,4 @@ export const WIKI_URL = 'https://docs.hyperplay.xyz/'
 export const GOG_LOGIN_URL =
   'https://auth.gog.com/auth?client_id=46899977096215655&redirect_uri=https%3A%2F%2Fembed.gog.com%2Fon_login_success%3Forigin%3Dclient&response_type=code&layout=galaxy'
 export const AMAZON_STORE = `https://gaming.amazon.com`
-export const ENABLE_AMAZON_STORE = false
 export const DEFAULT_BROWSER_PROFILE_IMPORT_COLOR = '202124'

--- a/src/frontend/screens/Library/components/LibraryTopBar/index.tsx
+++ b/src/frontend/screens/Library/components/LibraryTopBar/index.tsx
@@ -16,7 +16,7 @@ import { Category } from 'frontend/types'
 import { observer } from 'mobx-react-lite'
 import libraryState from '../../../../state/libraryState'
 import storeAuthState from 'frontend/state/storeAuthState'
-import { ENABLE_AMAZON_STORE } from 'frontend/constants'
+import { useFlags } from 'launchdarkly-react-client-sdk'
 
 export interface LibraryTopBarInterface {
   filters: DropdownItemType[]
@@ -37,6 +37,8 @@ export const LibraryTopBar = observer(
     otherFiltersData
   }: LibraryTopBarInterface): JSX.Element => {
     const { t } = useTranslation()
+    const flags = useFlags()
+    const ENABLE_AMAZON_STORE = flags.amazonStore
     const category = libraryState.category
 
     const isGOGLoggedin = storeAuthState.gog.username

--- a/src/frontend/screens/Login/index.tsx
+++ b/src/frontend/screens/Login/index.tsx
@@ -15,7 +15,7 @@ import ContextProvider from '../../state/ContextProvider'
 import { Background, Images } from '@hyperplay/ui'
 import libraryState from 'frontend/state/libraryState'
 import storeAuthState from 'frontend/state/storeAuthState'
-import { ENABLE_AMAZON_STORE } from 'frontend/constants'
+import { useFlags } from 'launchdarkly-react-client-sdk'
 
 export const epicLoginPath = '/loginweb/legendary'
 export const gogLoginPath = '/loginweb/gog'
@@ -36,6 +36,8 @@ export default React.memo(function NewLogin() {
   const [isAmazonLoggedIn, setIsAmazonLoggedIn] = useState(
     Boolean(storeAuthState.amazon.user_id)
   )
+  const flags = useFlags()
+  const ENABLE_AMAZON_STORE = flags.amazonStore
 
   const loginMessage = t(
     'login.message',


### PR DESCRIPTION
Added a feature flag from LaunchDarkly to replace the current hardcoded constant for enabling/disabling the Amazon Games integration:

[amazon-store-feature-flag.webm](https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/assets/26871415/0ad8c7ef-5c12-4ef0-978a-8f1c4ef034c8)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
