### PR TITLE
[FEAT-macOS] Download GPTK from Wine Manager

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -26,6 +26,7 @@ import { logError, logInfo, LogPrefix } from './logger/logger'
 import {
   getCrossover,
   getDefaultWine,
+  getSystemGamingPortingToolkitWine,
   getGamingPortingToolkitWine,
   getLinuxWineSet,
   getWineOnMac,
@@ -136,13 +137,15 @@ abstract class GlobalConfig {
       return new Set<WineInstallation>()
     }
 
+    const getGPTKWine = await getGamingPortingToolkitWine()
+    const getSystemGPTK = await getSystemGamingPortingToolkitWine()
     const crossover = await getCrossover()
     const wineOnMac = await getWineOnMac()
     const wineskinWine = await getWineskinWine()
-    const gamingPortingToolkitWine = await getGamingPortingToolkitWine()
 
     return new Set([
-      ...gamingPortingToolkitWine,
+      ...getGPTKWine,
+      ...getSystemGPTK,
       ...crossover,
       ...wineOnMac,
       ...wineskinWine

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -923,7 +923,7 @@ export async function downloadDefaultWine() {
         version.type === 'Wine-GE' && version.version.includes('Wine-GE-Proton')
       )
     } else if (isMac) {
-      return version.type === 'Wine-Crossover'
+      return version.type === 'Game-Porting-Toolkit'
     }
     return false
   })[0]

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -341,6 +341,56 @@ export async function getGamingPortingToolkitWine(): Promise<
     return gamingPortingToolkitWine
   }
 
+  const GPTK_ToolPath = join(toolsPath, 'game-porting-toolkit')
+  const wineGPTKPaths = new Set<string>()
+
+  if (existsSync(GPTK_ToolPath)) {
+    readdirSync(GPTK_ToolPath).forEach((path) => {
+      wineGPTKPaths.add(join(GPTK_ToolPath, path))
+    })
+  }
+
+  wineGPTKPaths.forEach((winePath) => {
+    const infoFilePath = join(winePath, 'Contents/Info.plist')
+    if (winePath && existsSync(infoFilePath)) {
+      const wineBin = join(winePath, '/Contents/Resources/wine/bin/wine64')
+      try {
+        const name = winePath.split('/').pop() || ''
+        if (existsSync(wineBin)) {
+          gamingPortingToolkitWine.add({
+            ...getWineExecs(wineBin),
+            lib: `${winePath}/Contents/Resources/wine/lib`,
+            lib32: `${winePath}/Contents/Resources/wine/lib`,
+            bin: wineBin,
+            name,
+            type: 'toolkit',
+            ...getWineExecs(wineBin)
+          })
+        }
+      } catch (error) {
+        logError(
+          `Error getting wine version for GPTK ${wineBin}`,
+          LogPrefix.GlobalConfig
+        )
+      }
+    }
+  })
+
+  return gamingPortingToolkitWine
+}
+
+/**
+ * Detects Gaming Porting Toolkit Wine installs on Mac
+ * @returns Promise<Set<WineInstallation>>
+ **/
+export async function getSystemGamingPortingToolkitWine(): Promise<
+  Set<WineInstallation>
+> {
+  const systemGPTK = new Set<WineInstallation>()
+  if (!isMac) {
+    return systemGPTK
+  }
+
   logInfo('Searching for Gaming Porting Toolkit Wine', LogPrefix.GlobalConfig)
   const { stdout } = await execAsync('mdfind wine64')
   const wineBin = stdout.split('\n').filter((p) => {
@@ -355,12 +405,14 @@ export async function getGamingPortingToolkitWine(): Promise<
     try {
       const { stdout: out } = await execAsync(`'${wineBin}' --version`)
       const version = out.split('\n')[0]
-      gamingPortingToolkitWine.add({
+      const GPTKDIR = join(dirname(wineBin), '..')
+
+      systemGPTK.add({
         ...getWineExecs(wineBin),
-        name: `GPTK Wine (DX11/DX12 Only) - ${version}`,
+        name: `GPTK System (DX11/DX12 Only) - ${version}`,
         type: 'toolkit',
-        lib: `${dirname(wineBin)}/../lib`,
-        lib32: `${dirname(wineBin)}/../lib`,
+        lib: join(GPTKDIR, 'lib'),
+        lib32: join(GPTKDIR, 'lib'),
         bin: wineBin
       })
     } catch (error) {
@@ -371,7 +423,7 @@ export async function getGamingPortingToolkitWine(): Promise<
     }
   }
 
-  return gamingPortingToolkitWine
+  return systemGPTK
 }
 
 export type AllowedWineFlags = Pick<

--- a/src/backend/wine/manager/downloader/constants.ts
+++ b/src/backend/wine/manager/downloader/constants.ts
@@ -21,3 +21,7 @@ export const WINECROSSOVER_URL =
 /// Url to Wine Staging for macOS github release page
 export const WINESTAGINGMACOS_URL =
   'https://api.github.com/repos/Gcenx/macOS_Wine_builds/releases'
+
+/// Url to Game Porting Toolkit from Gcenx github release page
+export const GPTK_URL =
+  'https://api.github.com/repos/Gcenx/game-porting-toolkit/releases'

--- a/src/backend/wine/manager/downloader/main.ts
+++ b/src/backend/wine/manager/downloader/main.ts
@@ -14,7 +14,8 @@ import {
   PROTON_URL,
   WINELUTRIS_URL,
   WINECROSSOVER_URL,
-  WINESTAGINGMACOS_URL
+  WINESTAGINGMACOS_URL,
+  GPTK_URL
 } from './constants'
 import { VersionInfo, Repositorys, State, ProgressInfo } from 'common/types'
 import {
@@ -131,6 +132,21 @@ async function getAvailableVersions({
           })
         break
       }
+      case Repositorys.GPTK: {
+        await fetchReleases({
+          url: GPTK_URL,
+          type: 'Game-Porting-Toolkit',
+          count: count
+        })
+          .then((fetchedReleases: VersionInfo[]) => {
+            releases.push(...fetchedReleases)
+          })
+          .catch((error: Error) => {
+            throw error
+          })
+        break
+      }
+
       default: {
         console.warn(
           `Unknown and not supported repository key passed! Skip fetch for ${repo}`

--- a/src/backend/wine/manager/downloader/utilities.ts
+++ b/src/backend/wine/manager/downloader/utilities.ts
@@ -33,6 +33,8 @@ async function fetchReleases({
           const release_data = {} as VersionInfo
           release_data.version = type.includes('Wine')
             ? `Wine-${release.tag_name}`
+            : type.includes('Toolkit')
+            ? `${release.tag_name}`
             : `Proton-${release.tag_name}`
           release_data.type = type
           release_data.date = release.published_at.split('T')[0]

--- a/src/backend/wine/manager/utils.ts
+++ b/src/backend/wine/manager/utils.ts
@@ -36,7 +36,11 @@ async function updateWineVersionInfos(
   if (fetch) {
     logInfo('Fetching upstream information...', LogPrefix.WineDownloader)
     const repositorys = isMac
-      ? [Repositorys.WINECROSSOVER, Repositorys.WINESTAGINGMACOS]
+      ? [
+          Repositorys.WINECROSSOVER,
+          Repositorys.WINESTAGINGMACOS,
+          Repositorys.GPTK
+        ]
       : [Repositorys.WINEGE, Repositorys.PROTONGE]
     await getAvailableVersions({
       repositorys,
@@ -96,6 +100,10 @@ async function installWineVersion(
     mkdirSync(`${toolsPath}/proton`, { recursive: true })
   }
 
+  if (isMac && !existsSync(`${toolsPath}/game-porting-toolkit`)) {
+    mkdirSync(`${toolsPath}/game-porting-toolkit`, { recursive: true })
+  }
+
   logInfo(
     `Start installation of wine version ${release.version}`,
     LogPrefix.WineDownloader
@@ -103,6 +111,8 @@ async function installWineVersion(
 
   const installDir = release?.type?.includes('Wine')
     ? `${toolsPath}/wine`
+    : release.type.includes('Toolkit')
+    ? `${toolsPath}/game-porting-toolkit`
     : `${toolsPath}/proton`
 
   try {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -692,6 +692,7 @@ export type Type =
   | 'Wine-Kron4ek'
   | 'Wine-Crossover'
   | 'Wine-Staging-macOS'
+  | 'Game-Porting-Toolkit'
 
 /**
  * Interface contains information about a version
@@ -721,7 +722,8 @@ export enum Repositorys {
   PROTON,
   WINELUTRIS,
   WINECROSSOVER,
-  WINESTAGINGMACOS
+  WINESTAGINGMACOS,
+  GPTK
 }
 
 /**

--- a/src/frontend/screens/WineManager/index.tsx
+++ b/src/frontend/screens/WineManager/index.tsx
@@ -33,22 +33,28 @@ export default React.memo(function WineManager(): JSX.Element | null {
     value: 'winege',
     enabled: isLinux
   }
-  const winecrossover: WineManagerUISettings = {
-    type: 'Wine-Crossover',
-    value: 'winecrossover',
+
+  const gamePortingToolkit: WineManagerUISettings = {
+    type: 'Game-Porting-Toolkit',
+    value: 'gpt',
     enabled: !isLinux
   }
 
   const [repository, setRepository] = useState<WineManagerUISettings>(
-    isLinux ? winege : winecrossover
+    isLinux ? winege : gamePortingToolkit
   )
   const [wineManagerSettings, setWineManagerSettings] = useState<
     WineManagerUISettings[]
   >([
     { type: 'Wine-GE', value: 'winege', enabled: isLinux },
     { type: 'Proton-GE', value: 'protonge', enabled: isLinux },
+    { type: 'Game-Porting-Toolkit', value: 'gpt', enabled: !isLinux },
     { type: 'Wine-Crossover', value: 'winecrossover', enabled: !isLinux },
-    { type: 'Wine-Staging-macOS', value: 'winestagingmacos', enabled: !isLinux }
+    {
+      type: 'Wine-Staging-macOS',
+      value: 'winestagingmacos',
+      enabled: !isLinux
+    }
   ])
 
   const getWineVersions = (repo: Type) => {


### PR DESCRIPTION
This PR adds the ability to download and set up Apple's gaming porting toolkit from the Gcenx repository directly from the wine manager.

It also makes it the default wine on a clean install if no other wine is found.

## Games I tested and worked out of the box:
- The Fabled
- Bushi
- Darkthrone
- Last Resort
- Uldor Dread arena

Most of them ask to install the UE prerequisites and fail.
But clicking on the game again makes it work, so might be that the VCRedist is failing to install because it was already installed before, but I cannot confirm that.

### How to test
- Go to the wine manager and download the GPTK
<img width="717" alt="Screenshot 2024-01-09 at 13 08 39" src="https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/assets/26871415/9925e213-4637-44fd-b062-f3796072e779">

- On the Game settings, make sure you have a new and clean prefix:
<img width="941" alt="Screenshot 2024-01-09 at 13 09 21" src="https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/assets/26871415/2781c3ac-7eb5-4079-af3e-289fa8c80737">

- Enable the Stats Overlay
- Launch the Game
- Check if the Stats shows: Rosetta 1.1


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
