### PR TITLE
[FIX] Check for games updates on startup

### DIFF
--- a/src/frontend/components/UI/ErrorComponent/index.tsx
+++ b/src/frontend/components/UI/ErrorComponent/index.tsx
@@ -21,7 +21,6 @@ export default function ErrorComponent({ message }: { message: string }) {
           className="button is-footer"
           onClick={async () =>
             libraryState.refreshLibrary({
-              checkForUpdates: true,
               runInBackground: false
             })
           }

--- a/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
+++ b/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
@@ -33,7 +33,10 @@ export default observer(function SidebarLinks() {
       (storeAuthState.gog.username && !libraryState.gogLibrary.length) ||
       (storeAuthState.amazon.user_id && !libraryState.amazonLibrary.length)
     if (shouldRefresh) {
-      return libraryState.refreshLibrary({ runInBackground: true })
+      return libraryState.refreshLibrary({
+        runInBackground: true,
+        checkForUpdates: false
+      })
     }
     return
   }

--- a/src/frontend/screens/Login/index.tsx
+++ b/src/frontend/screens/Login/index.tsx
@@ -60,7 +60,10 @@ export default React.memo(function NewLogin() {
   }, [storeAuthState.epic.username, storeAuthState.gog.username, storeAuthState.amazon.user_id, t])
 
   async function handleLibraryClick() {
-    await libraryState.refreshLibrary({ runInBackground: false })
+    await libraryState.refreshLibrary({
+      runInBackground: false,
+      checkForUpdates: false
+    })
     navigate('/library')
   }
 

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -279,6 +279,7 @@ class GlobalState extends PureComponent<Props> {
     libraryState.category = 'all'
     libraryState.refreshLibrary({
       runInBackground: false,
+      checkForUpdates: false,
       library: runner
     })
   }
@@ -457,7 +458,6 @@ class GlobalState extends PureComponent<Props> {
         )
         // This avoids calling legendary again before the previous process is killed when canceling
         libraryState.refreshLibrary({
-          checkForUpdates: true,
           runInBackground: true,
           library: runner
         })
@@ -469,7 +469,11 @@ class GlobalState extends PureComponent<Props> {
         })
       }
 
-      libraryState.refreshLibrary({ runInBackground: true, library: runner })
+      libraryState.refreshLibrary({
+        runInBackground: true,
+        library: runner,
+        checkForUpdates: false
+      })
       this.setState({ libraryStatus: newLibraryStatus })
     }
   }
@@ -540,7 +544,6 @@ class GlobalState extends PureComponent<Props> {
     window.api.handleRefreshLibrary(
       async (e: Electron.IpcRendererEvent, runner: Runner) => {
         libraryState.refreshLibrary({
-          checkForUpdates: true,
           runInBackground: true,
           library: runner
         })
@@ -592,7 +595,6 @@ class GlobalState extends PureComponent<Props> {
 
     if (legendaryUser || gogUser || amazonUser) {
       libraryState.refreshLibrary({
-        checkForUpdates: true,
         runInBackground: Boolean(libraryState.epicLibrary.length)
       })
     }

--- a/src/frontend/state/libraryState.ts
+++ b/src/frontend/state/libraryState.ts
@@ -111,8 +111,8 @@ class LibraryState {
     })
   }
 
-  async refresh(library?: Runner | 'all', checkUpdates = false): Promise<void> {
-    if (checkUpdates && library) {
+  async refresh(library?: Runner | 'all', checkUpdates = true): Promise<void> {
+    if (checkUpdates) {
       try {
         this.gameUpdates = await window.api.checkGameUpdates()
       } catch (error) {
@@ -160,7 +160,7 @@ class LibraryState {
   }
 
   refreshSelectedLibrary = async ({
-    checkForUpdates,
+    checkForUpdates = true,
     runInBackground = true
   }: RefreshOptions): Promise<void> => {
     return this.refreshLibrary({
@@ -171,7 +171,7 @@ class LibraryState {
   }
 
   refreshLibrary = async ({
-    checkForUpdates,
+    checkForUpdates = true,
     runInBackground = true,
     library = undefined
   }: RefreshOptions): Promise<void> => {


### PR DESCRIPTION
This fixes the issue with HP not checking for game updates on startup, leading users to play outdated games unless they hit the refresh button.

`checkUpdates` option is now `true` by default on all places and set to `false` only on the places we do not need it, like on a new login and browsing around.

### To test
- With games in need to update for any library, check if you can reproduce the issue on the stable release or main branch.
- When opening the library no game will show that it needs update, only after hitting the refresh button.
- Open the library again on this build and check if you can see the update icon on the game after the refresh finishes.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
