### PR TITLE
[FIX] Don't show Cloud Saves for HP and Sideloaded Games

### DIFF
--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -321,8 +321,11 @@ export default observer(function GamePage(): JSX.Element | null {
     const isLinuxNative = isLinux.includes(installPlatform ?? '')
     const isBrowserGame = gameInfo.browserUrl
     const isNative = isWin || isMacNative || isLinuxNative || isBrowserGame
+    const isHyperPlayGame = runner === 'hyperplay'
 
-    const showCloudSaveInfo = cloud_save_enabled && !isLinuxNative
+    const showCloudSaveInfo =
+      is_installed && !isBrowserGame && !isHyperPlayGame && !isSideloaded
+    const isCloudSaveSupported = cloud_save_enabled && !isLinuxNative
     const supportsWeb3 = gameInfo.web3?.supported
 
     /*
@@ -471,9 +474,9 @@ export default observer(function GamePage(): JSX.Element | null {
                   <div className="col2-item italic">
                     {supportsWeb3 ? t('box.yes') : t('box.no')}
                   </div>
-                  {is_installed && !isBrowserGame && (
+                  {showCloudSaveInfo && (
                     <>
-                      {showCloudSaveInfo ? (
+                      {isCloudSaveSupported ? (
                         <>
                           <div className="hp-subtitle">
                             {t('info.syncsaves')}

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -474,9 +474,9 @@ export default observer(function GamePage(): JSX.Element | null {
                   <div className="col2-item italic">
                     {supportsWeb3 ? t('box.yes') : t('box.no')}
                   </div>
-                  {showCloudSaveInfo && (
+                  {is_installed && !isBrowserGame && (
                     <>
-                      {isCloudSaveSupported ? (
+                      {showCloudSaveInfo && (
                         <>
                           <div className="hp-subtitle">
                             {t('info.syncsaves')}
@@ -487,21 +487,10 @@ export default observer(function GamePage(): JSX.Element | null {
                             }}
                             className="col2-item italic"
                           >
-                            {autoSyncSaves ? t('enabled') : t('disabled')}
-                          </div>
-                        </>
-                      ) : (
-                        <>
-                          <div className="hp-subtitle">
-                            {t('info.syncsaves')}:
-                          </div>
-                          <div
-                            style={{
-                              color: '#F45460'
-                            }}
-                            className="col2-item italic"
-                          >
-                            {t('cloud_save_unsupported', 'Unsupported')}
+                            {!isCloudSaveSupported &&
+                              t('cloud_save_unsupported', 'Unsupported')}
+                            {isCloudSaveSupported &&
+                              (autoSyncSaves ? t('enabled') : t('disabled'))}
                           </div>
                         </>
                       )}


### PR DESCRIPTION
Remove the cloud saves info for HP and Sideloaded games on game page since it is not useful.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
