### PR TITLE
[FIX] Uninstall Status for HP Games

### DIFF
--- a/src/backend/api/library.ts
+++ b/src/backend/api/library.ts
@@ -22,7 +22,7 @@ export const uninstall = async (
     game_name: appName,
     store_name: runner
   })
-  if (runner === 'sideload' || runner === 'hyperplay') {
+  if (runner === 'sideload') {
     return ipcRenderer.invoke('removeApp', {
       appName,
       shouldRemovePrefix,

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -266,7 +266,7 @@ export default observer(function GamePage(): JSX.Element | null {
       }
     }
     updateConfig()
-  }, [status, libraryState.epicLibrary, libraryState.gogLibrary, gameInfo, isSettingsModalOpen, isOffline])
+  }, [status, libraryState.hyperPlayLibrary, libraryState.epicLibrary, libraryState.gogLibrary, gameInfo, isSettingsModalOpen, isOffline])
 
   function handleModal() {
     setShowModal({ game: appName, show: true })

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -439,7 +439,7 @@ class GlobalState extends PureComponent<Props> {
 
     // in these cases we just add the new status
     if (
-      ['installing', 'updating', 'playing', 'extracting', 'preparing'].includes(
+      ['installing', 'updating', 'playing', 'extracting', 'preparing', 'uninstalling'].includes(
         status
       )
     ) {

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -440,9 +440,14 @@ class GlobalState extends PureComponent<Props> {
 
     // in these cases we just add the new status
     if (
-      ['installing', 'updating', 'playing', 'extracting', 'preparing', 'uninstalling'].includes(
-        status
-      )
+      [
+        'installing',
+        'updating',
+        'playing',
+        'extracting',
+        'preparing',
+        'uninstalling'
+      ].includes(status)
     ) {
       currentApp.status = status
       newLibraryStatus.push(currentApp)

--- a/src/frontend/state/libraryState.ts
+++ b/src/frontend/state/libraryState.ts
@@ -120,7 +120,6 @@ class LibraryState {
       }
     }
 
-
     this.hyperPlayLibrary = hyperPlayLibraryStore.get('games', [])
 
     this.epicLibrary = libraryStore.get('library', [])

--- a/src/frontend/state/libraryState.ts
+++ b/src/frontend/state/libraryState.ts
@@ -120,6 +120,9 @@ class LibraryState {
       }
     }
 
+
+    this.hyperPlayLibrary = hyperPlayLibraryStore.get('games', [])
+
     this.epicLibrary = libraryStore.get('library', [])
     if (
       storeAuthState.epic.username &&
@@ -152,7 +155,6 @@ class LibraryState {
 
     this.refreshSideloadedLibrary()
 
-    this.hyperPlayLibrary = hyperPlayLibraryStore.get('games', [])
     this.hiddenGames.list = configStore.get('games.hidden', [])
 
     this.refreshing = false


### PR DESCRIPTION
- Fix the Game Page not updating right after uninstalling an HP game.
- Fix tracking of uninstalling HP Games.

This was due to HP games calling `removeApp` instead of `uninstall`, so it was skipping the tracking and the status update.
But I also changed some other few lines to make the process more resilient and the HP library refreshes quicker.


### How To test

- On stable release or main branch, uninstall a HyperPlay game.
- Checks That there is no notification and the page take several seconds to update the status
- On this branch it will be a notification and the page will update instantly just like the games from other Stores.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
