### PR TITLE
[TECH] Add writeManifestFile function to write manifest.json file

### DIFF
--- a/src/backend/storeManagers/hyperplay/games.ts
+++ b/src/backend/storeManagers/hyperplay/games.ts
@@ -17,13 +17,7 @@ import {
   ExtractZipService,
   ExtractZipProgressResponse
 } from 'backend/services/ExtractZipService'
-import {
-  existsSync,
-  mkdirSync,
-  rmSync,
-  readdirSync,
-  writeFileSync
-} from 'graceful-fs'
+import { existsSync, mkdirSync, rmSync, readdirSync } from 'graceful-fs'
 import {
   isMac,
   isWindows,
@@ -71,6 +65,7 @@ import { DownloadItem } from 'electron'
 import { waitForItemToDownload } from 'backend/utils/downloadFile/download_file'
 import { cancelQueueExtraction } from 'backend/downloadmanager/downloadqueue'
 import { captureException } from '@sentry/electron'
+import Store from 'electron-store'
 
 interface ProgressDownloadingItem {
   DownloadItem: DownloadItem
@@ -1221,12 +1216,10 @@ function writeManifestFile(installedInfo: Partial<InstalledInfo>) {
   if (!installedInfo.install_path) {
     return
   }
+  const store = new Store({
+    cwd: installedInfo.install_path,
+    name: installedInfo.appName
+  })
 
-  const manifestPath = path.join(
-    path.dirname(installedInfo.install_path!),
-    'manifest.json'
-  )
-  const manifest = JSON.stringify(installedInfo, null, 2)
-
-  return writeFileSync(manifestPath, manifest, { encoding: 'utf8', flag: 'w' })
+  return store.set('manifest', installedInfo)
 }

--- a/src/backend/storeManagers/hyperplay/games.ts
+++ b/src/backend/storeManagers/hyperplay/games.ts
@@ -22,7 +22,6 @@ import {
   mkdirSync,
   rmSync,
   readdirSync,
-  unlinkSync,
   writeFileSync
 } from 'graceful-fs'
 import {
@@ -1219,16 +1218,15 @@ export async function forceUninstall(appName: string): Promise<void> {
 }
 
 function writeManifestFile(installedInfo: Partial<InstalledInfo>) {
+  if (!installedInfo.install_path) {
+    return
+  }
+
   const manifestPath = path.join(
     path.dirname(installedInfo.install_path!),
     'manifest.json'
   )
   const manifest = JSON.stringify(installedInfo, null, 2)
 
-  // delete manifest if exists
-  if (existsSync(manifestPath)) {
-    unlinkSync(manifestPath)
-  }
-
-  return writeFileSync(manifestPath, manifest)
+  return writeFileSync(manifestPath, manifest, { encoding: 'utf8', flag: 'w' })
 }


### PR DESCRIPTION
This PR adds a method called `writeManifestFile` that creates a file with basic info for the installed game so we can use it to properly import previously installed games.

- Call the method on Game Install
- Call the method on Game Update
- Call the method on `getGameInfo` to update currently installed games (temporary)


### How to test

- For installed games, after opening HP and going to the library or the game page, a new file should appear on the game install folder called `appName.json` (eg.: `0xf544a85580b166cc656be3015bde2a5eba4fa832867a04a45b49a87d2e374af5.json`. It won't be on the actual folder with the game files but on the parent folder with the developer name.
- For new installs, the file should appear just after the installation.


### Exemple manifest

```
{
  "appName": "0xf544a85580b166cc656be3015bde2a5eba4fa832867a04a45b49a87d2e374af5",
  "install_path": "/home/user/Games/HyperPlay/yokaikingdom/onisquest",
  "executable": "/home/user/Games/HyperPlay/yokaikingdom/onisquest/OnisQuest.exe",
  "install_size": "1208832914",
  "is_dlc": false,
  "version": "0.0.32",
  "platform": "windows_amd64",
  "channelName": "main"
}

```


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
