### PR TITLE
[FIX] Install Redistributables for HP games

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -750,7 +750,7 @@ ipcMain.on('showConfigFileInFolder', async (event, appName) => {
   return openUrlOrFile(path.join(gamesConfigPath, `${appName}.json`))
 })
 
-async function runWineCommandOnGame(
+export async function runWineCommandOnGame(
   runner: string,
   appName: string,
   { commandParts, wait = false, protonVerb, startFolder }: WineCommandArgs

--- a/src/backend/storeManagers/hyperplay/games.ts
+++ b/src/backend/storeManagers/hyperplay/games.ts
@@ -228,6 +228,27 @@ type DistArgs = {
 
 // for Windows games only
 const installDistributables = async ({ gamePath, appName }: DistArgs) => {
+  if (!isWindows || isLinux || (isMac && isNative(appName))) {
+    return
+  }
+
+  const window = getMainWindow()
+
+  window?.webContents.send(`progressUpdate-${appName}`, {
+    appName,
+    runner: 'hyperplay',
+    folder: gamePath,
+    status: 'preparing',
+    progress: {
+      folder: gamePath,
+      percent: 0,
+      diskSpeed: 0,
+      downSpeed: 0,
+      bytes: 0,
+      eta: null
+    }
+  })
+
   const possibleFolders = ['dist', 'redist', 'Dist', 'Redist']
   let executables: string[] = []
 


### PR DESCRIPTION
This should make the `installDistributables`  work properly now.
It will also fix the issue where the Overlay appears on top of the redist install since it thinks that the game was launched already.

The current method expects a `dist` folder on the game folder, which is not true for most games.

Most of them have a `Redist` folder but in different locations, sometimes it includes other subfolders with the proper executable, something like `GameFolder/Engine/Extras/Redist/en-us/file.exe`.

To handle that I've added some methods to search for the executables on folders recursively called `dist`, `Dist`, `Redist`, and `redist`. Once it finds it it searches for the executable on this folder and calls it with the `quiet` parameter to avoid most of the setup Windows. 

Catching all of them would be hard so we might need to adjust those in the future or ask the devs to follow a pattern.

## How to test

### Considerations

- First, some games does not have those dependencies. Most Unity games I tested (MCVerse, DarkThrone) don't.
- Most of the Unreal engine games have it (Celeros, The Fabled)
- So this installation will only be triggered if the game has a redist file to be launched. Most of these games are the ones that asks to install UE pre-requisites when launched.
- On Windows just installing the game is fine.
- On Linux and macOS it will run the setup using the selected Wine version when installing the game.
- Make sure to test on a clean prefix on these systems (Check Use Default Compatibility Settings)

### To see if it worked:
- The game needs to have a Redist/OR/Dist folder with a file `UEPrereqSetup_x64.exe`.
- Preparing should be the status just after the extraction
- Check the installation logs and look for a message like: `Installing distributable ${executable}`

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
