### PR TITLE
[TECH] Skip update on QA Mode

### DIFF
--- a/src/frontend/helpers/library.ts
+++ b/src/frontend/helpers/library.ts
@@ -9,6 +9,7 @@ import {
 import { TFunction } from 'i18next'
 import { getGameInfo } from './index'
 import { DialogModalOptions } from 'frontend/types'
+import authState from 'frontend/state/authState'
 
 const storage: Storage = window.localStorage
 
@@ -124,7 +125,7 @@ const launch = async ({
   hasUpdate,
   showDialogModal
 }: LaunchOptions): Promise<{ status: 'done' | 'error' | 'abort' }> => {
-  if (hasUpdate) {
+  if (hasUpdate && !authState.isQaModeActive) {
     const { ignoreGameUpdates } = await window.api.requestGameSettings(appName)
 
     if (ignoreGameUpdates && runner !== 'hyperplay') {

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -65,6 +65,7 @@ import libraryState from 'frontend/state/libraryState'
 import { NileInstallInfo } from 'common/types/nile'
 import DMQueueState from 'frontend/state/DMQueueState'
 import { useEstimatedUncompressedSize } from 'frontend/hooks/useEstimatedUncompressedSize'
+import authState from 'frontend/state/authState'
 
 export default observer(function GamePage(): JSX.Element | null {
   const { appName, runner } = useParams() as { appName: string; runner: Runner }
@@ -705,7 +706,7 @@ export default observer(function GamePage(): JSX.Element | null {
   }
 
   function getPlayLabel(): React.ReactNode {
-    if (hasUpdate) {
+    if (hasUpdate && !authState.isQaModeActive) {
       return t('label.playing.update', 'Update')
     }
 
@@ -860,7 +861,9 @@ export default observer(function GamePage(): JSX.Element | null {
   }
 
   function handlePlay() {
-    if (hasUpdate) {
+    const isQAMode = authState.isQaModeActive
+
+    if (hasUpdate && !isQAMode) {
       return async () => {
         await updateGame(gameInfo)
       }

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -693,7 +693,7 @@ export default observer(function GamePage(): JSX.Element | null {
     if (notAvailable) {
       return 'tertiary'
     }
-    if (isQueued || hasUpdate) {
+    if (isQueued || (hasUpdate && !authState.isQaModeActive)) {
       return 'secondary'
     }
     if (isUpdating) {

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -113,7 +113,11 @@ const GameCard = ({
 
   const getState = (): GameCardState => {
     const showUpdateButton =
-      hasUpdate && !isUpdating && !isQueued && !notAvailable && !authState.isQaModeActive
+      hasUpdate &&
+      !isUpdating &&
+      !isQueued &&
+      !notAvailable &&
+      !authState.isQaModeActive
     if (notSupportedGame) {
       return 'NOT_SUPPORTED'
     }
@@ -200,7 +204,12 @@ const GameCard = ({
       // update
       label: t('button.update', 'Update'),
       onClick: handleClickStopBubbling(async () => updateGame(gameInfo)),
-      show: hasUpdate && !isUpdating && !isQueued && !notAvailable && !authState.isQaModeActive
+      show:
+        hasUpdate &&
+        !isUpdating &&
+        !isQueued &&
+        !notAvailable &&
+        !authState.isQaModeActive
     },
     {
       // install

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -26,6 +26,7 @@ import classNames from 'classnames'
 import { useGetDownloadStatusText } from 'frontend/hooks/useGetDownloadStatusText'
 import libraryState from 'frontend/state/libraryState'
 import DMQueueState from 'frontend/state/DMQueueState'
+import authState from 'frontend/state/authState'
 
 interface Card {
   buttonClick: () => void
@@ -112,7 +113,7 @@ const GameCard = ({
 
   const getState = (): GameCardState => {
     const showUpdateButton =
-      hasUpdate && !isUpdating && !isQueued && !notAvailable
+      hasUpdate && !isUpdating && !isQueued && !notAvailable && !authState.isQaModeActive
     if (notSupportedGame) {
       return 'NOT_SUPPORTED'
     }
@@ -199,7 +200,7 @@ const GameCard = ({
       // update
       label: t('button.update', 'Update'),
       onClick: handleClickStopBubbling(async () => updateGame(gameInfo)),
-      show: hasUpdate && !isUpdating && !isQueued
+      show: hasUpdate && !isUpdating && !isQueued && !notAvailable && !authState.isQaModeActive
     },
     {
       // install


### PR DESCRIPTION
Update GamePage and Gamecard to ignore the force update when testing with QA Mode.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
