### PR TITLE
[UX] Use download folder install path for .temp

### DIFF
--- a/src/backend/storeManagers/hyperplay/games.ts
+++ b/src/backend/storeManagers/hyperplay/games.ts
@@ -30,7 +30,8 @@ import {
   isWindows,
   isLinux,
   configFolder,
-  getValidateLicenseKeysApiUrl
+  getValidateLicenseKeysApiUrl,
+  configStore
 } from 'backend/constants'
 import {
   downloadFile,
@@ -559,7 +560,11 @@ function getZipFileName(
   platformInfo: PlatformConfig
 ): { directory: string; filename: string } {
   const zipName = encodeURI(platformInfo.name)
-  const tempfolder = path.join(configFolder, 'hyperplay', '.temp', appName)
+  const downloadFolder = configStore.get(
+    'settings.defaultInstallPath',
+    configFolder
+  )
+  const tempfolder = path.join(downloadFolder, 'hyperplay', '.temp', appName)
 
   if (!existsSync(tempfolder)) {
     mkdirSync(tempfolder, { recursive: true })


### PR DESCRIPTION
Download into a .temp folder in the default install path by default. If the default install path setting is not set, use the config folder as was used previously

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
