### PR TITLE
[Fix] Space available calculation

### DIFF
--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -162,12 +162,12 @@ export default function DownloadDialog({
   const { i18n, t } = useTranslation('gamepage')
   const { t: tr } = useTranslation()
 
-  const compressedSize = gameInstallInfo?.manifest?.disk_size || 0
-  const gameDwnloadSize = gameInstallInfo?.manifest?.download_size || 0
+  const diskSize = gameInstallInfo?.manifest?.disk_size || 0
+  const gameDownloadSize = gameInstallInfo?.manifest?.download_size || 0
   const uncompressedSize = useEstimatedUncompressedSize(
     platformToInstall,
-    compressedSize,
-    gameDwnloadSize
+    diskSize,
+    gameDownloadSize
   )
 
   const haveSDL = sdls.length > 0
@@ -316,7 +316,7 @@ export default function DownloadDialog({
       if (gameInstallInfo?.manifest?.disk_size) {
         let notEnoughDiskSpace = free < uncompressedSize
         // downloads the entire zip, then extracts the entire zip, then deletes the zip, so we need space for both
-        let spaceLeftAfter = size(free - Number(uncompressedSize) - Number(compressedSize))
+        let spaceLeftAfter = size(free - Number(uncompressedSize) - Number(gameDownloadSize))
 
         const partiallyDownloaded = previousProgress.folder === installPath
         if (partiallyDownloaded) {
@@ -326,7 +326,7 @@ export default function DownloadDialog({
 
           // downloads the entire zip, then extracts the entire zip, then deletes the zip, so we need space for both
           spaceLeftAfter = size(
-            free - Number(uncompressedSize) - (progress / 100) * compressedSize
+            free - Number(uncompressedSize) - (progress / 100) * gameDownloadSize
           )
         }
 
@@ -346,7 +346,6 @@ export default function DownloadDialog({
     gameInstallInfo.game.owned_dlc.length > 0
 
   const DLCList = gameInstallInfo?.game?.owned_dlc
-  const gameDownloadSize = gameInstallInfo?.manifest?.download_size
   const downloadSize = () => {
     if (gameDownloadSize !== undefined && gameInstallInfo !== null) {
       if (previousProgress.folder === installPath) {

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -316,7 +316,9 @@ export default function DownloadDialog({
       if (gameInstallInfo?.manifest?.disk_size) {
         let notEnoughDiskSpace = free < uncompressedSize
         // downloads the entire zip, then extracts the entire zip, then deletes the zip, so we need space for both
-        let spaceLeftAfter = size(free - Number(uncompressedSize) - Number(gameDownloadSize))
+        let spaceLeftAfter = size(
+          free - Number(uncompressedSize) - Number(gameDownloadSize)
+        )
 
         const partiallyDownloaded = previousProgress.folder === installPath
         if (partiallyDownloaded) {
@@ -326,7 +328,9 @@ export default function DownloadDialog({
 
           // downloads the entire zip, then extracts the entire zip, then deletes the zip, so we need space for both
           spaceLeftAfter = size(
-            free - Number(uncompressedSize) - (progress / 100) * gameDownloadSize
+            free -
+              Number(uncompressedSize) -
+              (progress / 100) * gameDownloadSize
           )
         }
 

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -162,10 +162,12 @@ export default function DownloadDialog({
   const { i18n, t } = useTranslation('gamepage')
   const { t: tr } = useTranslation()
 
+  const compressedSize = gameInstallInfo?.manifest?.disk_size || 0
+  const gameDwnloadSize = gameInstallInfo?.manifest?.download_size || 0
   const uncompressedSize = useEstimatedUncompressedSize(
     platformToInstall,
-    gameInstallInfo?.manifest?.disk_size || 0,
-    gameInstallInfo?.manifest?.download_size || 0
+    compressedSize,
+    gameDwnloadSize
   )
 
   const haveSDL = sdls.length > 0
@@ -313,14 +315,18 @@ export default function DownloadDialog({
       )
       if (gameInstallInfo?.manifest?.disk_size) {
         let notEnoughDiskSpace = free < uncompressedSize
-        let spaceLeftAfter = size(free - Number(uncompressedSize))
-        if (previousProgress.folder === installPath) {
+        // downloads the entire zip, then extracts the entire zip, then deletes the zip, so we need space for both
+        let spaceLeftAfter = size(free - Number(uncompressedSize) - Number(compressedSize))
+
+        const partiallyDownloaded = previousProgress.folder === installPath
+        if (partiallyDownloaded) {
           const progress = 100 - getProgress(previousProgress)
           notEnoughDiskSpace =
             free < (progress / 100) * Number(uncompressedSize)
 
+          // downloads the entire zip, then extracts the entire zip, then deletes the zip, so we need space for both
           spaceLeftAfter = size(
-            free - (progress / 100) * Number(uncompressedSize)
+            free - Number(uncompressedSize) - (progress / 100) * compressedSize
           )
         }
 


### PR DESCRIPTION
Fixes space available calculation to download size + uncompressed size to match the new behavior in https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/pull/742

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
