### PR TITLE
[UX] Install to .temp in game destination directory

### DIFF
--- a/src/backend/storeManagers/hyperplay/games.ts
+++ b/src/backend/storeManagers/hyperplay/games.ts
@@ -29,9 +29,7 @@ import {
   isMac,
   isWindows,
   isLinux,
-  configFolder,
-  getValidateLicenseKeysApiUrl,
-  configStore
+  getValidateLicenseKeysApiUrl
 } from 'backend/constants'
 import {
   downloadFile,
@@ -557,14 +555,11 @@ function sanitizeFileName(filename: string) {
 
 function getZipFileName(
   appName: string,
-  platformInfo: PlatformConfig
+  platformInfo: PlatformConfig,
+  destinationPath: string
 ): { directory: string; filename: string } {
   const zipName = encodeURI(platformInfo.name)
-  const downloadFolder = configStore.get(
-    'settings.defaultInstallPath',
-    configFolder
-  )
-  const tempfolder = path.join(downloadFolder, 'hyperplay', '.temp', appName)
+  const tempfolder = path.join(destinationPath, '.temp', appName)
 
   if (!existsSync(tempfolder)) {
     mkdirSync(tempfolder, { recursive: true })
@@ -803,7 +798,7 @@ export async function install(
     }
 
     logInfo(`Installing ${title} to ${dirpath}...`, LogPrefix.HyperPlay)
-    const zipPathInfo = getZipFileName(appName, platformInfo)
+    const zipPathInfo = getZipFileName(appName, platformInfo, destinationPath)
     directory = zipPathInfo.directory
     fileName = zipPathInfo.filename
 
@@ -915,7 +910,7 @@ export async function extract(
     }
 
     const { title } = gameInfo
-    const zipPathInfo = getZipFileName(appName, platformInfo)
+    const zipPathInfo = getZipFileName(appName, platformInfo, destinationPath)
     directory = zipPathInfo.directory
     fileName = zipPathInfo.filename
 


### PR DESCRIPTION
Move the download install directory inside the destination directory so all downloads and extractions happen on the same directory for accurate space requirements estimates

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
