### PR TITLE
[UX] Delete HyperPlay app config folder on reset

### DIFF
--- a/src/backend/constants.ts
+++ b/src/backend/constants.ts
@@ -305,5 +305,6 @@ export {
   nileInstalled,
   nileLibrary,
   nileUserData,
-  cachedUbisoftInstallerPath
+  cachedUbisoftInstallerPath,
+  appFolder
 }

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -41,14 +41,14 @@ import si from 'systeminformation'
 import {
   fixAsarPath,
   getSteamLibraries,
-  configPath,
   gamesConfigPath,
   icon,
   isWindows,
   publicDir,
   isMac,
   configStore,
-  isLinux
+  isLinux,
+  appFolder
 } from './constants'
 import {
   logError,
@@ -487,9 +487,13 @@ function clearCache(library?: 'gog' | 'legendary' | 'nile') {
 }
 
 function resetApp() {
-  const appConfigFolders = [gamesConfigPath, configPath]
+  const appConfigFolders = [appFolder]
   appConfigFolders.forEach((folder) => {
-    rmSync(folder, { recursive: true, force: true })
+    try {
+      rmSync(folder, { recursive: true, force: true })
+    } catch (e) {
+      console.error(`Error while removing ${folder} ${e}`)
+    }
   })
   // wait a sec to avoid racing conditions
   setTimeout(() => {


### PR DESCRIPTION
# Summary
To reset the entirety of HyperPlay, including the MetaMask extension, you will now just need to click this "Reset HyperPlay" button

![image](https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/assets/27568879/bf74949a-0a10-4ee7-97c1-b421b84c506f)

Previously, it would only delete the `appFolder/hyperplay/GamesConfig` and `appFolder/hyperplay/config.json` files
 
# Testing
1. Create or import MetaMask extension
2. Reset the app
3. It should relaunch HyperPlay with no games in library and no MetaMask extension
4. Create or import another MetaMask extension
 
---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
