### PR TITLE
[FIX] Install Event Tracking

### DIFF
--- a/src/backend/downloadmanager/utils.ts
+++ b/src/backend/downloadmanager/utils.ts
@@ -104,6 +104,7 @@ async function installQueueElement(params: InstallParams): Promise<{
 
     if (status === 'error') {
       errorMessage(error ?? 'Unknown error')
+      trackFailedInstall(error ?? 'Unknown error')
       return { status }
     }
 

--- a/src/backend/downloadmanager/utils.ts
+++ b/src/backend/downloadmanager/utils.ts
@@ -95,10 +95,6 @@ async function installQueueElement(params: InstallParams): Promise<{
 
     const { status, error } = await installInstance()
 
-    if (status === 'error') {
-      errorMessage(error ?? '')
-    }
-
     sendFrontendMessage('gameStatusUpdate', {
       appName,
       runner,
@@ -106,7 +102,12 @@ async function installQueueElement(params: InstallParams): Promise<{
       folder: path
     })
 
-    if (status === 'done')
+    if (status === 'error') {
+      errorMessage(error ?? '')
+      return { status }
+    }
+
+    if (status === 'done') {
       trackEvent({
         event: 'Game Install Success',
         properties: {
@@ -117,7 +118,19 @@ async function installQueueElement(params: InstallParams): Promise<{
           platform_arch: platformToInstall
         }
       })
-    else trackFailedInstall(`${error}`)
+      return { status }
+    }
+    if (status === 'abort') {
+      trackEvent({
+        event: 'Game Install Canceled',
+        properties: {
+          game_name: appName,
+          store_name: runner,
+          game_title: title
+        }
+      })
+      return { status }
+    }
 
     return { status }
   } catch (error) {
@@ -133,7 +146,13 @@ async function installQueueElement(params: InstallParams): Promise<{
     })
   }
 
-  function trackFailedInstall(error: unknown) {
+  function trackFailedInstall(error: string) {
+    const errorsToIgnore = ['EPERM', 'EACCES', 'EBUSY']
+
+    if (errorsToIgnore.some((err) => error?.includes(err))) {
+      return
+    }
+
     trackEvent({
       event: 'Game Install Failed',
       properties: {

--- a/src/backend/downloadmanager/utils.ts
+++ b/src/backend/downloadmanager/utils.ts
@@ -148,12 +148,6 @@ async function installQueueElement(params: InstallParams): Promise<{
   }
 
   function trackFailedInstall(error: string) {
-    const errorsToIgnore = ['EPERM', 'EACCES', 'EBUSY']
-
-    if (errorsToIgnore.some((err) => error?.includes(err))) {
-      return
-    }
-
     trackEvent({
       event: 'Game Install Failed',
       properties: {

--- a/src/backend/downloadmanager/utils.ts
+++ b/src/backend/downloadmanager/utils.ts
@@ -103,7 +103,7 @@ async function installQueueElement(params: InstallParams): Promise<{
     })
 
     if (status === 'error') {
-      errorMessage(error ?? '')
+      errorMessage(error ?? 'Unknown error')
       return { status }
     }
 


### PR DESCRIPTION
Fixes the 'Game Install Failed' to only trigger when `status === 'error'`.
Right now it was being sent also for when it was aborted so canceling or pausing the downloads were triggering failed as well.

There is also another event for Abort that is not related with this one, this one tracks the Failed event and should be triggered only on `error`.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
