### PR TITLE
[Fix] Prevent wine install on windows

### DIFF
--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -992,6 +992,9 @@ export async function isMacSonomaOrHigher() {
 }
 
 export async function downloadDefaultWine() {
+  if (isWindows) {
+    return
+  }
   // refresh wine list
   await updateWineVersionInfos(true)
   // get list of wines on wineDownloaderInfoStore

--- a/src/backend/wine/manager/ipc_handler.ts
+++ b/src/backend/wine/manager/ipc_handler.ts
@@ -11,8 +11,12 @@ import {
   deleteAbortController
 } from '../../utils/aborthandler/aborthandler'
 import { sendFrontendMessage } from '../../main_window'
+import { isWindows } from 'backend/constants'
 
-ipcMain.handle('installWineVersion', async (e, release) => {
+ipcMain.handle('installWineVersion', async (_e, release) => {
+  if (isWindows) {
+    return 'error'
+  }
   const onProgress = (state: State, progress?: ProgressInfo) => {
     sendFrontendMessage('progressOfWineManager' + release.version, {
       state,
@@ -25,10 +29,13 @@ ipcMain.handle('installWineVersion', async (e, release) => {
     createAbortController(release.version).signal
   )
   deleteAbortController(release.version)
-  return result
+  return result ?? 'error'
 })
 
 ipcMain.handle('refreshWineVersionInfo', async (e, fetch?) => {
+  if (isWindows) {
+    return
+  }
   try {
     await updateWineVersionInfos(fetch)
     return

--- a/src/backend/wine/manager/utils.ts
+++ b/src/backend/wine/manager/utils.ts
@@ -14,7 +14,7 @@ import {
 } from 'common/types'
 
 import { getAvailableVersions, installVersion } from './downloader/main'
-import { toolsPath, isMac } from '../../constants'
+import { toolsPath, isMac, isWindows } from '../../constants'
 import { sendFrontendMessage } from '../../main_window'
 import { TypeCheckedStoreBackend } from 'backend/electron_store'
 
@@ -30,6 +30,9 @@ async function updateWineVersionInfos(
   fetch = false,
   count = 50
 ): Promise<WineVersionInfo[]> {
+  if (isWindows) {
+    return []
+  }
   let releases: WineVersionInfo[] = []
 
   logInfo('Updating wine versions info', LogPrefix.WineDownloader)
@@ -100,6 +103,9 @@ async function installWineVersion(
   onProgress: (state: State, progress?: ProgressInfo) => void,
   abortSignal: AbortSignal
 ) {
+  if (isWindows) {
+    return
+  }
   let updatedInfo: WineVersionInfo
 
   if (!existsSync(`${toolsPath}/wine`)) {


### PR DESCRIPTION
Wine was being installed on Windows, making the app slow to launch

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
