### PR TITLE
[Summon Quest] Add LD flag, error handling, metrics events

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -599,12 +599,6 @@ if (!gotTheLock) {
       configStore.set('settings.ldUser', ldUser)
     }
 
-    console.log(
-      'XXXXXXXXXXXXXXXX \n \n \n initializing ld main client ',
-      LDEnvironmentId,
-      ldUser,
-      ldOptions
-    )
     ldMainClient = LDElectron.initializeInMain(
       LDEnvironmentId,
       ldUser,

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -246,8 +246,10 @@ ipcMain.on('focusMainWindow', () => {
 })
 
 async function completeHyperPlayQuest() {
-  const completeHpSummonQuestIsActive =
-    ldMainClient.allFlags['completeHpSummonQuestIsActive']
+  const completeHpSummonQuestIsActive = ldMainClient.variation(
+    'complete-hp-summon-quest',
+    false
+  )
   if (!completeHpSummonQuestIsActive) {
     return
   }
@@ -597,6 +599,12 @@ if (!gotTheLock) {
       configStore.set('settings.ldUser', ldUser)
     }
 
+    console.log(
+      'XXXXXXXXXXXXXXXX \n \n \n initializing ld main client ',
+      LDEnvironmentId,
+      ldUser,
+      ldOptions
+    )
     ldMainClient = LDElectron.initializeInMain(
       LDEnvironmentId,
       ldUser,

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -246,28 +246,47 @@ ipcMain.on('focusMainWindow', () => {
 })
 
 async function completeHyperPlayQuest() {
-  logInfo('Completing HyperPlay Quest', LogPrefix.Backend)
-  const cookieString = await getPartitionCookies({
-    partition: 'persist:auth',
-    url: DEV_PORTAL_URL
-  })
-
-  const response = await fetch(`${DEV_PORTAL_URL}/api/hyperplay-quest`, {
-    method: 'POST',
-    headers: {
-      Cookie: cookieString
-    }
-  })
-
-  if (!response.ok) {
-    const error = await response.json()
-    logError(
-      `Failed to complete summon task: ${
-        error?.message ?? response.statusText
-      }`,
-      LogPrefix.Backend
-    )
+  const completeHpSummonQuestIsActive =
+    ldMainClient.allFlags['completeHpSummonQuestIsActive']
+  if (!completeHpSummonQuestIsActive) {
     return
+  }
+  logInfo('Completing HyperPlay Quest', LogPrefix.Backend)
+  try {
+    const cookieString = await getPartitionCookies({
+      partition: 'persist:auth',
+      url: DEV_PORTAL_URL
+    })
+
+    const response = await fetch(`${DEV_PORTAL_URL}/api/hyperplay-quest`, {
+      method: 'POST',
+      headers: {
+        Cookie: cookieString
+      }
+    })
+
+    if (!response.ok) {
+      const error = await response.json()
+      logError(
+        `Failed to complete summon task: ${
+          error?.message ?? response.statusText
+        }`,
+        LogPrefix.Backend
+      )
+      trackEvent({
+        event: 'HyperPlay Summon Quest Failed'
+      })
+      return
+    }
+
+    trackEvent({
+      event: 'HyperPlay Summon Quest Succeeded'
+    })
+  } catch (err) {
+    logError(`Error completing Summon quest ${err}`, LogPrefix.HyperPlay)
+    trackEvent({
+      event: 'HyperPlay Summon Quest Failed'
+    })
   }
 
   logInfo(`Completed HyperPlay Summon task`, LogPrefix.Backend)

--- a/src/backend/metrics/types.ts
+++ b/src/backend/metrics/types.ts
@@ -288,6 +288,18 @@ export interface HyperPlayLaunched {
   sensitiveProperties?: never
 }
 
+export interface HyperPlaySummonQuestFailed {
+  event: 'HyperPlay Summon Quest Failed'
+  properties?: never
+  sensitiveProperties?: never
+}
+
+export interface HyperPlaySummonQuestSucceeded {
+  event: 'HyperPlay Summon Quest Succeeded'
+  properties?: never
+  sensitiveProperties?: never
+}
+
 export type PossibleMetricPayloads =
   | MetricsOptIn
   | MetricsOptOut
@@ -317,5 +329,7 @@ export type PossibleMetricPayloads =
   | GameInstallPaused
   | GameInstallResumed
   | HyperPlayLaunched
+  | HyperPlaySummonQuestFailed
+  | HyperPlaySummonQuestSucceeded
 
 export type PossibleMetricEventNames = PossibleMetricPayloads['event']


### PR DESCRIPTION
This was giving `fetch failed` on HyperPlay startup and in general does not need to be active until the Summon quest is live
