### PR TITLE
[FIX] Flathub release workflow

### DIFF
--- a/flathub/update-flathub.ts
+++ b/flathub/update-flathub.ts
@@ -101,7 +101,7 @@ async function main() {
   )
 
   const releaseNotesJson = JSON.parse(releaseNotesStdOut)
-  const releaseNotesComponents = releaseNotesJson.body.split('\n')
+  const releaseNotesComponents: string[] = releaseNotesJson.body.split('\n')
 
   const hpXmlJson = convert.xml2js(hpXml, { compact: false }) as Element
   const releaseNotesElements: Element[] = []
@@ -111,20 +111,26 @@ async function main() {
     if (i === 0) continue
     if (!releaseComponent_i.startsWith('*')) continue
     if (releaseComponent_i.includes('http')) continue
+    const li = releaseComponent_i
+      .replace(/\n/g, '')
+      .replace(/\r/g, '')
+      .replace(/\t/g, '')
+      .slice(1)
+      .trim()
     const releaseNoteElement: Element = {
       type: 'element',
       name: 'li',
       elements: [
         {
           type: 'text',
-          text: releaseComponent_i.slice(1) //remove the asterisk
+          text: li
         }
       ]
     }
     releaseNotesElements.push(releaseNoteElement)
   }
 
-  const componentsTag = hpXmlJson.elements?.[0]
+  const componentsTag = hpXmlJson.elements?.[1]
   const releasesTag = componentsTag?.elements?.find(
     (val) => val.name === 'releases'
   ) //.releases.release.description.ul =
@@ -136,7 +142,9 @@ async function main() {
     throw 'releaseListTag ul undefined'
   }
   releaseListTag.elements = releaseNotesElements
-  hpXml = convert.js2xml(hpXmlJson)
+  hpXml = convert.js2xml(hpXmlJson, {
+    spaces: 4
+  })
   fs.writeFileSync(xmlFilePath, hpXml)
 
   console.log(

--- a/flathub/update-flathub.ts
+++ b/flathub/update-flathub.ts
@@ -13,7 +13,7 @@ async function main() {
 
   // update url in xyz.hyperplay.HyperPlay.yml
   console.log('updating url in xyz.hyperplay.HyperPlay.yml')
-  const ymlFilePath = '../xyz.hyperplay.HyperPlay/xyz.hyperplay.HyperPlay.yml'
+  const ymlFilePath = './xyz.hyperplay.HyperPlay/xyz.hyperplay.HyperPlay.yml'
   let hpYml = fs.readFileSync(ymlFilePath).toString()
 
   const releaseString = `https://github.com/${repoName}/releases/download/${
@@ -55,7 +55,7 @@ async function main() {
     'updating release version and date on xml tag in xyz.hyperplay.HyperPlay.metainfo.xml'
   )
   const xmlFilePath =
-    '../xyz.hyperplay.HyperPlay/xyz.hyperplay.HyperPlay.metainfo.xml'
+    './xyz.hyperplay.HyperPlay/xyz.hyperplay.HyperPlay.metainfo.xml'
   let hpXml = fs.readFileSync(xmlFilePath).toString()
   const date = new Date()
   const isoDate = date.toISOString().slice(0, 10)

--- a/package.json
+++ b/package.json
@@ -330,6 +330,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-react": "^7.29.4",
+    "fast-xml-parser": "^4.3.5",
     "husky": "^7.0.4",
     "i18next-parser": "^6.3.0",
     "jest": "^29.7.0",
@@ -345,8 +346,7 @@
     "typescript": "^5.3.2",
     "vite": "^3.2.7",
     "vite-plugin-electron": "^0.10.2",
-    "vite-plugin-svgr": "^2.2.2",
-    "xml-js": "^1.6.11"
+    "vite-plugin-svgr": "^2.2.2"
   },
   "optionalDependencies": {},
   "packageManager": "yarn@1.22.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7357,6 +7357,13 @@ fast-safe-stringify@^2.0.6, fast-safe-stringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
+fast-xml-parser@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.3.5.tgz#e2f2a2ae8377e9c3dc321b151e58f420ca7e5ccc"
+  integrity sha512-sWvP1Pl8H03B8oFJpFR3HE31HUfwtX7Rlf9BNsvdpujD4n7WMhfmu8h9wOV2u+c1k0ZilTADhPqypzx2J690ZQ==
+  dependencies:
+    strnum "^1.0.5"
+
 fastq@^1.6.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
@@ -12734,6 +12741,11 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
+strnum@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
+  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
+
 stylis@4.0.13:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.13.tgz#f5db332e376d13cc84ecfe5dace9a2a51d954c91"
@@ -13890,13 +13902,6 @@ ws@~8.11.0:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
   integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==
-
-xml-js@^1.6.11:
-  version "1.6.11"
-  resolved "https://registry.yarnpkg.com/xml-js/-/xml-js-1.6.11.tgz#927d2f6947f7f1c19a316dd8eea3614e8b18f8e9"
-  integrity sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==
-  dependencies:
-    sax "^1.2.4"
 
 xml-name-validator@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Fix the current issues:
- Workflow failed to add release notes and open the PR because the structure of the original XML changed due to Flathub made it mandatory to add a Copyright comment at the top. So I adjusted the position of the `ul` element to the correct one.
- Moved from xml2js over to fast-XML-parse that is the most updated lib and doesn't mess with formatting.

Tested it running the command locally and the result can be observed on this PR:
https://github.com/flathub/xyz.hyperplay.HyperPlay/pull/80

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
