### PR TITLE
[Fix] EBUSY during download cancel

### DIFF
--- a/src/backend/api/downloadmanager.ts
+++ b/src/backend/api/downloadmanager.ts
@@ -84,8 +84,8 @@ export const handleDMQueueInformation = (
 export const cancelDownload = (removeDownloaded: boolean) =>
   ipcRenderer.send('cancelDownload', removeDownloaded)
 
-export const cancelExtraction = (appName: string) =>
-  ipcRenderer.send('cancelExtraction', appName)
+export const cancelExtraction = (appName: string, removeDownloaded: boolean) =>
+  ipcRenderer.send('cancelExtraction', appName, removeDownloaded)
 
 export const resumeCurrentDownload = () =>
   ipcRenderer.send('resumeCurrentDownload')

--- a/src/backend/downloadmanager/ipc_handler.ts
+++ b/src/backend/downloadmanager/ipc_handler.ts
@@ -27,8 +27,11 @@ ipcMain.on('cancelDownload', (e, removeDownloaded) => {
   cancelCurrentDownload({ removeDownloaded })
 })
 
-ipcMain.on('cancelExtraction', (e, appName: string) => {
-  cancelExtraction(appName)
-})
+ipcMain.on(
+  'cancelExtraction',
+  (e, appName: string, removeDownloaded: boolean) => {
+    cancelExtraction(appName, removeDownloaded)
+  }
+)
 
 ipcMain.handle('getDMQueueInformation', getQueueInformation)

--- a/src/backend/utils/rmFolderRecursive.ts
+++ b/src/backend/utils/rmFolderRecursive.ts
@@ -1,0 +1,42 @@
+import fs from 'fs'
+
+export function deleteFolderRecursive(path: string) {
+  try {
+    console.log('deleting ', path)
+    if (fs.existsSync(path)) {
+      const stats = fs.statSync(path)
+
+      if (stats.isDirectory()) {
+        console.log('deleting existing path ', path)
+        const paths = fs.readdirSync(path)
+        for (const file of paths) {
+          const curPath = path + '/' + file
+          try {
+            if (fs.lstatSync(curPath).isDirectory()) {
+              // recurse
+              deleteFolderRecursive(curPath)
+            } else {
+              // delete file
+              fs.rmSync(curPath)
+              console.log('deleting file ', curPath)
+            }
+          } catch (err) {
+            console.log(`Error deleting file ${err} ${curPath}`)
+          }
+        }
+        try {
+          fs.rmdirSync(path)
+        } catch (err) {
+          console.log(`Error deleting folder ${err} ${path}`)
+        }
+      }
+      // if the path passed is a file
+      else if (stats.isFile()) {
+        fs.rmSync(path, { force: true, maxRetries: 3, retryDelay: 100 })
+        console.log('deleting file ', path)
+      }
+    }
+  } catch (err) {
+    console.error(`errorroeroeoeroeoror ${err}`)
+  }
+}

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -143,7 +143,7 @@ interface SyncIPCFunctions extends HyperPlaySyncIPCFunctions {
   openGameInEpicStore: (url: string) => void
   resumeCurrentDownload: () => void
   cancelDownload: (removeDownloaded: boolean) => void
-  cancelExtraction: (appName: string) => void
+  cancelExtraction: (appName: string, removeDownloaded: boolean) => void
   copyWalletConnectBaseURIToClipboard: () => void
   closeAuthModal: () => void
   'auth:accountConnected': () => void

--- a/src/frontend/components/UI/StopInstallationModal/index.tsx
+++ b/src/frontend/components/UI/StopInstallationModal/index.tsx
@@ -74,7 +74,7 @@ export default function StopInstallationModal(props: StopInstallProps) {
               storage.setItem(app_name, JSON.stringify(latestProgress))
 
               if (isExtracting) {
-                window.api.cancelExtraction(app_name)
+                window.api.cancelExtraction(app_name, false)
 
                 return
               }
@@ -86,7 +86,7 @@ export default function StopInstallationModal(props: StopInstallProps) {
               props.onClose()
 
               if (isExtracting) {
-                window.api.cancelExtraction(app_name)
+                window.api.cancelExtraction(app_name, true)
               } else {
                 window.api.cancelDownload(true)
               }


### PR DESCRIPTION
Removing the directory when canceling an in progress download was being called twice and failing with EBUSY. Selecting to keep the files would still attempt to delete them.

TBD how to handle cancel during extraction with Yes/No to keeping download files.
