### PR TITLE
[FIX] Check disk space not working

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ const srcAliases = ['backend', 'frontend', 'common'].map((aliasName) => {
   }
 })
 
-const dependenciesToNotExternalize = ['check-disk-space']
+const dependenciesToNotExternalize = ['@hyperplay/check-disk-space']
 
 export default defineConfig(({ mode }) => ({
   main: {


### PR DESCRIPTION
Fix an issue introduced after migrating to Vite5 where the check-disk-space library was not working correctly. So the calculation was failing on the install modal.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
