### PR TITLE
[Fix] Move frontend ready

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -668,12 +668,6 @@ ipcMain.once('loadingScreenReady', () => {
   logInfo('Loading Screen Ready', LogPrefix.Backend)
 })
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-let resolveFrontendReady = () => {}
-export const frontendReady = new Promise<void>((res) => {
-  resolveFrontendReady = res
-})
-
 ipcMain.once('frontendReady', () => {
   logInfo('Frontend Ready', LogPrefix.Backend)
   handleProtocol([openUrlArgument, ...process.argv])
@@ -683,7 +677,6 @@ ipcMain.once('frontendReady', () => {
   }, 5000)
 
   watchLibraryChanges()
-  resolveFrontendReady()
 })
 
 // Maybe this can help with white screens


### PR DESCRIPTION
There is an issue with `src/backend/main.ts` being bundled twice. This is due to `frontendReady` being imported by a submodule

You can see that the `ipcMain.handle("callTool"...` is included twice
<img width="382" alt="callTool 19996" src="https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/assets/27568879/20ba8d33-cea3-45d6-af18-ee2a39fe084b">
<img width="393" alt="callTool 17896" src="https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/assets/27568879/33b037f0-33d4-4b3a-8f64-fcb0ef40b3f7">

And the download queue (and other code more than likely) is called twice. for example:
```
(14:30:05) INFO:    [Backend]:          Starting the Download Queue
(14:30:05) INFO:    [Backend]:          Starting the Download Queue
```

After this PR's changes, this becomes
```
(14:30:05) INFO:    [Backend]:          Starting the Download Queue
```

`frontendReady` is only being used in this one place so moving it to the submodule does not break any other code