### PR TITLE
[CD Fix] Mac release node version & add windows signpath force flag

### DIFF
--- a/.github/workflows/release_macOS.yml
+++ b/.github/workflows/release_macOS.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'latest'
+          node-version: '18'
           cache: 'yarn'
 
       - name: Reconfigure git to use HTTP authentication

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -79,6 +79,7 @@ jobs:
             -SigningPolicySlug "Release_Signing" `
             -OutputArtifactPath "signed/$exeName" `
             -WaitForCompletion
+            -Force
 
       - name: Install powershell-yaml
         run: Install-Module -Name powershell-yaml -Force


### PR DESCRIPTION
Change node version to 18

Add force to overwrite previous version of same name for windows on signpath
