### PR TITLE
[Feat] Add go back and go forward arrows to browser games

### DIFF
--- a/src/frontend/OverlayManager/index.module.scss
+++ b/src/frontend/OverlayManager/index.module.scss
@@ -1,9 +1,11 @@
+$topNavBarHeight: 30px;
+
 .browserGame {
   position: absolute;
   left: 0px;
   right: 0px;
   bottom: 0px;
-  top: 30px;
+  top: $topNavBarHeight;
 }
 
 .topBar {
@@ -11,7 +13,7 @@
   left: 0px;
   right: 0px;
   top: 0px;
-  height: 30px;
+  height: $topNavBarHeight;
   display: flex;
   flex-direction: row;
 }
@@ -31,11 +33,12 @@
 }
 
 .overlayToggleHint {
-  padding: 10px;
   display: inline-block;
   white-space: pre-line;
   max-width: 600px;
   z-index: 3;
+  position: absolute;
+  top: calc($topNavBarHeight + 10px);
 }
 
 .bgFilter {
@@ -50,7 +53,7 @@
 
 .closeOverlayText {
   position: absolute;
-  top: var(--space-md);
+  top: calc($topNavBarHeight + 10px);
   left: 50%;
   transform: translateX(-50%);
   z-index: 3;

--- a/src/frontend/OverlayManager/index.module.scss
+++ b/src/frontend/OverlayManager/index.module.scss
@@ -3,7 +3,17 @@
   left: 0px;
   right: 0px;
   bottom: 0px;
+  top: 30px;
+}
+
+.topBar {
+  position: absolute;
+  left: 0px;
+  right: 0px;
   top: 0px;
+  height: 30px;
+  display: flex;
+  flex-direction: row;
 }
 
 .txnToastContainer {

--- a/src/frontend/OverlayManager/index.tsx
+++ b/src/frontend/OverlayManager/index.tsx
@@ -165,7 +165,12 @@ const OverlayManager = observer(function ({
       ) : null}
       {url !== 'ignore' && OverlayState.renderState.showBrowserGame ? (
         <div>
-          <WebviewControls webview={webviewRef.current} initURL={''} openInBrowser={false} disableUrl={true} />
+          <WebviewControls
+            webview={webviewRef.current}
+            initURL={''}
+            openInBrowser={false}
+            disableUrl={true}
+          />
           <webview
             src={url}
             className={BrowserGameStyles.browserGame}

--- a/src/frontend/OverlayManager/index.tsx
+++ b/src/frontend/OverlayManager/index.tsx
@@ -7,11 +7,12 @@ import { observer } from 'mobx-react-lite'
 import OverlayState from 'frontend/state/OverlayState'
 import WalletState from 'frontend/state/WalletState'
 import { t } from 'i18next'
-import { Button, Images } from '@hyperplay/ui'
+import { Button } from '@hyperplay/ui'
 import DeviceState from 'frontend/state/DeviceState'
 import ExtensionManager from 'frontend/ExtensionManager'
 import TransactionState from 'frontend/state/TransactionState'
 import { WebviewTag } from 'electron'
+import WebviewControls from 'frontend/components/UI/WebviewControls'
 
 interface BrowserGameProps {
   appName: string
@@ -152,14 +153,6 @@ const OverlayManager = observer(function ({
   }
   const webviewRef = useRef<WebviewTag>(null)
 
-  function goBack() {
-    webviewRef.current?.goBack()
-  }
-
-  function goForward() {
-    webviewRef.current?.goForward()
-  }
-
   /* eslint-disable react/no-unknown-property */
   return (
     <div
@@ -172,14 +165,7 @@ const OverlayManager = observer(function ({
       ) : null}
       {url !== 'ignore' && OverlayState.renderState.showBrowserGame ? (
         <div>
-          <div className={BrowserGameStyles.topBar}>
-            <Button onClick={goBack} type="secondary" size="icon">
-              <Images.ArrowLeft />
-            </Button>
-            <Button onClick={goForward} type="secondary" size="icon">
-              <Images.RightArrow />
-            </Button>
-          </div>
+          <WebviewControls webview={webviewRef.current} initURL={''} openInBrowser={false} disableUrl={true} />
           <webview
             src={url}
             className={BrowserGameStyles.browserGame}

--- a/src/frontend/OverlayManager/index.tsx
+++ b/src/frontend/OverlayManager/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import BrowserGameStyles from './index.module.scss'
 import ToastManager from './ToastManager'
 import { PROVIDERS } from 'common/types/proxy-types'
@@ -7,10 +7,11 @@ import { observer } from 'mobx-react-lite'
 import OverlayState from 'frontend/state/OverlayState'
 import WalletState from 'frontend/state/WalletState'
 import { t } from 'i18next'
-import { Button } from '@hyperplay/ui'
+import { Button, Images } from '@hyperplay/ui'
 import DeviceState from 'frontend/state/DeviceState'
 import ExtensionManager from 'frontend/ExtensionManager'
 import TransactionState from 'frontend/state/TransactionState'
+import { WebviewTag } from 'electron'
 
 interface BrowserGameProps {
   appName: string
@@ -149,6 +150,15 @@ const OverlayManager = observer(function ({
     style.width = '100%'
     style.height = '100%'
   }
+  const webviewRef = useRef<WebviewTag>(null)
+
+  function goBack() {
+    webviewRef.current?.goBack()
+  }
+
+  function goForward() {
+    webviewRef.current?.goForward()
+  }
 
   /* eslint-disable react/no-unknown-property */
   return (
@@ -161,19 +171,30 @@ const OverlayManager = observer(function ({
         <Overlay appName={appName} runner={runner} />
       ) : null}
       {url !== 'ignore' && OverlayState.renderState.showBrowserGame ? (
-        <webview
-          src={url}
-          className={BrowserGameStyles.browserGame}
-          partition={
-            WalletState.provider === PROVIDERS.METAMASK_MOBILE ||
-            PROVIDERS.WALLET_CONNECT
-              ? 'persist:InPageWindowEthereumExternalWallet'
-              : undefined
-          }
-          webpreferences="contextIsolation=true"
-          // setting = to {true} does not work :(
-          allowpopups={trueAsStr}
-        />
+        <div>
+          <div className={BrowserGameStyles.topBar}>
+            <Button onClick={goBack} type="secondary" size="icon">
+              <Images.ArrowLeft />
+            </Button>
+            <Button onClick={goForward} type="secondary" size="icon">
+              <Images.RightArrow />
+            </Button>
+          </div>
+          <webview
+            src={url}
+            className={BrowserGameStyles.browserGame}
+            partition={
+              WalletState.provider === PROVIDERS.METAMASK_MOBILE ||
+              PROVIDERS.WALLET_CONNECT
+                ? 'persist:InPageWindowEthereumExternalWallet'
+                : undefined
+            }
+            webpreferences="contextIsolation=true"
+            // setting = to {true} does not work :(
+            allowpopups={trueAsStr}
+            ref={webviewRef}
+          />
+        </div>
       ) : null}
     </div>
   )

--- a/src/frontend/components/UI/WebviewControls/index.tsx
+++ b/src/frontend/components/UI/WebviewControls/index.tsx
@@ -15,6 +15,7 @@ interface WebviewControlsProps {
   webview: WebviewTag | null
   initURL: string
   openInBrowser: boolean
+  disableUrl?: boolean
 }
 
 function removeSelection(event: SyntheticEvent<unknown>) {
@@ -31,7 +32,8 @@ function removeSelection(event: SyntheticEvent<unknown>) {
 export default function WebviewControls({
   webview,
   initURL,
-  openInBrowser
+  openInBrowser,
+  disableUrl
 }: WebviewControlsProps) {
   const [url, setUrl] = React.useState(initURL)
   const { t } = useTranslation()
@@ -40,7 +42,11 @@ export default function WebviewControls({
 
   useEffect(() => {
     if (webview) {
-      const eventCallback = () => setUrl(webview.getURL())
+      const eventCallback = () => {
+        if (!disableUrl){
+          setUrl(webview.getURL())
+        }
+      }
       webview.addEventListener('did-navigate-in-page', eventCallback)
       webview.addEventListener('did-navigate', eventCallback)
       webview.addEventListener('did-navigate-in-page', () => {
@@ -78,10 +84,10 @@ export default function WebviewControls({
     [webview]
   )
 
-  const _url = new URL(url)
+  const _url = url !== '' ? new URL(url) : null
   const allowList = ['store.hyperplay.xyz', 'docs.hyperplay.xyz']
 
-  if (allowList.includes(_url.host)) return null
+  if (_url && allowList.includes(_url.host)) return null
 
   return (
     <div className="WebviewControls">

--- a/src/frontend/components/UI/WebviewControls/index.tsx
+++ b/src/frontend/components/UI/WebviewControls/index.tsx
@@ -43,7 +43,7 @@ export default function WebviewControls({
   useEffect(() => {
     if (webview) {
       const eventCallback = () => {
-        if (!disableUrl){
+        if (!disableUrl) {
           setUrl(webview.getURL())
         }
       }


### PR DESCRIPTION
# Summary

Adds go back and go forward arrow icon buttons to browser games.

### Note
I attempted to set the disabled boolean based on `webview.canGoBack` but there was an issue attempting to use `webview.current` before the `"dom-ready"` event had fired. Correct me if I'm wrong, but I don't think this is a blocker.

![image](https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/assets/27568879/a45f93bd-b89c-4ed7-aac8-c97598018175)

# Testing
https://app.qase.io/project/HC?case=332&previewMode=modal
