### PR TITLE
[Fix] Show hyperplay games on recently played

### DIFF
--- a/src/frontend/screens/Library/components/RecentlyPlayed/index.tsx
+++ b/src/frontend/screens/Library/components/RecentlyPlayed/index.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 function getRecentGames(
   libraries: GameInfo[],
-  limit: number,
+  limit: number = 5,
   onlyInstalled: boolean
 ): GameInfo[] {
   const recentGames = configStore.get('games.recent', [])

--- a/src/frontend/screens/Library/components/RecentlyPlayed/index.tsx
+++ b/src/frontend/screens/Library/components/RecentlyPlayed/index.tsx
@@ -42,6 +42,7 @@ export default React.memo(
       const { maxRecentGames } = await window.api.requestAppSettings()
       const newRecentGames = getRecentGames(
         [
+          ...libraryState.hyperPlayLibrary,
           ...libraryState.epicLibrary,
           ...libraryState.gogLibrary,
           ...libraryState.sideloadedLibrary,


### PR DESCRIPTION
Small fix to the recent played games not showing hyperplay games.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
