### PR TITLE
[TECH] Speed Up Big Libraries loading

### DIFF
--- a/src/backend/api/misc.ts
+++ b/src/backend/api/misc.ts
@@ -46,8 +46,8 @@ export const getAmazonLoginData = async () =>
 export const authAmazon = async (data: NileRegisterData) =>
   ipcRenderer.invoke('authAmazon', data)
 export const logoutAmazon = async () => ipcRenderer.invoke('logoutAmazon')
-export const checkGameUpdates = async () =>
-  ipcRenderer.invoke('checkGameUpdates')
+export const checkGameUpdates = async (runners: Runner[]) =>
+  ipcRenderer.invoke('checkGameUpdates', runners)
 export const refreshLibrary = async (library?: Runner | 'all') =>
   ipcRenderer.invoke('refreshLibrary', library)
 

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -803,26 +803,29 @@ ipcMain.handle('runWineCommand', async (e, args) => runWineCommand(args))
 
 /// IPC handlers begin here.
 
-ipcMain.handle('checkGameUpdates', async (): Promise<string[]> => {
-  let oldGames: string[] = []
-  const { autoUpdateGames } = GlobalConfig.get().getSettings()
-  for (const runner in libraryManagerMap) {
-    let gamesToUpdate = await libraryManagerMap[runner].listUpdateableGames()
-    if (autoUpdateGames) {
-      gamesToUpdate = await autoUpdate(runner as Runner, gamesToUpdate)
+ipcMain.handle(
+  'checkGameUpdates',
+  async (e, runners: Runner[]): Promise<string[]> => {
+    let oldGames: string[] = []
+    const { autoUpdateGames } = GlobalConfig.get().getSettings()
+    for (const runner of runners) {
+      let gamesToUpdate = await libraryManagerMap[runner].listUpdateableGames()
+      if (autoUpdateGames) {
+        gamesToUpdate = await autoUpdate(runner as Runner, gamesToUpdate)
+      }
+      oldGames = [...oldGames, ...gamesToUpdate]
     }
-    oldGames = [...oldGames, ...gamesToUpdate]
-  }
 
-  sendGameUpdatesNotifications().catch((e) =>
-    logError(
-      `Something went wrong sending update notifications: ${e}`,
-      LogPrefix.Backend
+    sendGameUpdatesNotifications().catch((e) =>
+      logError(
+        `Something went wrong sending update notifications: ${e}`,
+        LogPrefix.Backend
+      )
     )
-  )
 
-  return oldGames
-})
+    return oldGames
+  }
+)
 
 ipcMain.handle('getEpicGamesStatus', async () => isEpicServiceOffline())
 

--- a/src/backend/storeManagers/hyperplay/library.ts
+++ b/src/backend/storeManagers/hyperplay/library.ts
@@ -188,6 +188,11 @@ export async function listUpdateableGames(): Promise<string[]> {
   const updateableGames: string[] = []
   const currentHpLibrary = hpLibraryStore.get('games', [])
 
+  logInfo(
+    `Checking for updateable games in HyperPlay Library`,
+    LogPrefix.HyperPlay
+  )
+
   currentHpLibrary.map((val) => {
     if (
       val.install.platform === 'web' ||
@@ -226,6 +231,11 @@ export async function listUpdateableGames(): Promise<string[]> {
   function gameIsInstalled(val: GameInfo) {
     return Object.keys(val.install).length > 0
   }
+
+  logInfo(
+    `Found ${updateableGames.length} updateable games in HyperPlay Library`,
+    LogPrefix.HyperPlay
+  )
 
   return updateableGames
 }

--- a/src/backend/storeManagers/index.ts
+++ b/src/backend/storeManagers/index.ts
@@ -35,10 +35,10 @@ export const gameManagerMap: Record<Runner, GameManager> = {
 
 export const libraryManagerMap: Record<Runner, LibraryManager> = {
   hyperplay: HyperPlayLibraryManager,
-  sideload: SideloadLibraryManager,
-  gog: GOGLibraryManager,
   legendary: LegendaryLibraryManager,
-  nile: NileLibraryManager
+  gog: GOGLibraryManager,
+  nile: NileLibraryManager,
+  sideload: SideloadLibraryManager
 }
 
 function getDMElement(gameInfo: GameInfo, appName: string) {

--- a/src/backend/storeManagers/sideload/library.ts
+++ b/src/backend/storeManagers/sideload/library.ts
@@ -79,7 +79,6 @@ export function installState(appName: string, state: boolean) {
 }
 
 export async function refresh() {
-  logWarning(`refresh not implemented on Sideload Library Manager`)
   return null
 }
 
@@ -98,7 +97,6 @@ export function getGameInfo(appName: string, forceReload?: boolean): GameInfo {
 }
 
 export async function listUpdateableGames(): Promise<string[]> {
-  logWarning(`listUpdateableGames not implemented on Sideload Library Manager`)
   return []
 }
 

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -275,7 +275,7 @@ interface AsyncIPCFunctions extends HyperPlayAsyncIPCFunctions {
   runWineCommand: (
     args: WineCommandArgs
   ) => Promise<{ stdout: string; stderr: string }>
-  checkGameUpdates: () => Promise<string[]>
+  checkGameUpdates: (runners: Runner[]) => Promise<string[]>
   getEpicGamesStatus: () => Promise<boolean>
   updateAll: () => Promise<({ status: 'done' | 'error' | 'abort' } | null)[]>
   getMaxCpus: () => number

--- a/src/frontend/state/libraryState.ts
+++ b/src/frontend/state/libraryState.ts
@@ -113,11 +113,16 @@ class LibraryState {
 
   async refresh(library?: Runner | 'all', checkUpdates = true): Promise<void> {
     if (checkUpdates) {
-      try {
-        this.gameUpdates = await window.api.checkGameUpdates()
-      } catch (error) {
-        window.api.logError(`${error}`)
-      }
+      const hpUpdates = await window.api.checkGameUpdates(['hyperplay'])
+      this.gameUpdates = [...this.gameUpdates, ...hpUpdates]
+      window.api
+        .checkGameUpdates(['legendary', 'gog', 'nile'])
+        .then((otherUpdates) => {
+          this.gameUpdates = [...this.gameUpdates, ...otherUpdates]
+        })
+        .catch((error) => {
+          window.api.logError(`${error}`)
+        })
     }
 
     this.hyperPlayLibrary = hyperPlayLibraryStore.get('games', [])


### PR DESCRIPTION
I've noticed that when I am logged in on all stores with more than 550 games the first loading takes almost a minute to show the games. This is due to how slow checking for game updates is since it iterates through all runners and wait for each list to complete to then full-fill the promise, so longer the library slower it will be.

So I did a few small changes:
- Added the a `Runner[]` parameter to `checkGameUpdates`.
- Await only for the list of HyperPlay games, so will only block the thread for these.
- Call it again for the rest of the runners but without blocking the thread.

This way the behaviour will be:
- The list of games will appear right away since the hyperplay request is quite fast.
- All other games from other stores will load but the update status for the games will only change after a few seconds.

This has other benefit as well since HP games will go up to the list for auto updates and since most people use it for our games then makes no sense to block everything because of other runners.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
