### PR TITLE
[FIX] Logs override when calling from protocol

### DIFF
--- a/src/backend/logger/logfile.ts
+++ b/src/backend/logger/logfile.ts
@@ -39,6 +39,15 @@ const createLogFile = (filePath: string) => {
  * @returns path to current log file
  */
 export function createNewLogFileAndClearOldOnes(): createLogFileReturn {
+  if (!app.requestSingleInstanceLock()) {
+    return configStore.get('general-logs', {
+      currentLogFile: '',
+      lastLogFile: '',
+      legendaryLogFile: '',
+      gogdlLogFile: '',
+      nileLogFile: ''
+    })
+  }
   const date = new Date()
   const logDir = app.getPath('logs')
   const fmtDate = date.toISOString().replaceAll(':', '_')


### PR DESCRIPTION
Fix the current issue about the Logs being overriden when launching/installing the game from the game store from inside the client.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
