### PR TITLE
[Fix] Remove SRP direct link option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperplay",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "private": true,
   "main": "build/main/main.js",
   "homepage": "./",

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -98,12 +98,6 @@ function App() {
               path="metamaskSnaps"
               element={<WebView key="metamaskSnaps" />}
             />
-            <Route
-              path="metamaskSecretPhrase"
-              element={
-                <MetaMaskHome path="home.html#onboarding/import-with-recovery-phrase" />
-              }
-            />
             <Route path="metamaskPortfolio" element={<MetaMaskPortfolio />}>
               <Route path=":page" element={<MetaMaskPortfolio />} />
             </Route>

--- a/src/frontend/screens/Onboarding/walletSelection/screens/import/components/ImportAndCreateOptions/index.tsx
+++ b/src/frontend/screens/Onboarding/walletSelection/screens/import/components/ImportAndCreateOptions/index.tsx
@@ -1,10 +1,8 @@
 import React from 'react'
 import { ImportAndCreateOptionsProps } from '../../types'
 import ImportOption from 'frontend/screens/Onboarding/components/importOption'
-import { NavLink } from 'react-router-dom'
 import { t } from 'i18next'
 import styles from './index.module.scss'
-import { Collapse, Images } from '@hyperplay/ui'
 import { ImportableBrowser } from '@hyperplay/utils'
 
 export default function ImportAndCreateOptions({
@@ -31,46 +29,6 @@ export default function ImportAndCreateOptions({
     <div className={styles.importAndCreateOptionsContainer}>
       <div className={styles.importOptionsContainer}>
         {importableBrowserOptions}
-      </div>
-      <div className={styles.actionsContainer}>
-        <Collapse title="Advanced Options">
-          <div className={styles.actionsCollapseContainer}>
-            <div className={styles.infoBox}>
-              <Images.Info
-                fill="var(--color-alert-400)"
-                className={styles.infoIcon}
-              />
-              <div className={styles.infoText}>
-                {t(
-                  'hyperplay.onboarding.walletSelection.screens.import.useRecoveryPhraseInfo',
-                  `This feature is recommended for advanced users and developers. Your secret recovery phrase is stored locally in MetaMask and never shared with HyperPlay.`
-                )}
-                <span
-                  onClick={() => window.api.openHyperplaySite()}
-                  className={styles.infoLink}
-                >
-                  {t(
-                    'hyperplay.onboarding.walletSelection.screens.import.learnMore',
-                    `Learn more.`
-                  )}
-                </span>
-              </div>
-            </div>
-            <NavLink to="/metamaskSecretPhrase">
-              <ImportOption
-                override="recovery"
-                classNames={styles.importSecretRecoveryButton}
-                title={t(
-                  'hyperplay.onboarding.walletSelection.screens.import.useRecoveryPhrase',
-                  `Import Using Secret Recovery Phrase`
-                )}
-                onClick={async () => {
-                  handleImportMmExtensionClicked('SECRET_PHRASE')
-                }}
-              />
-            </NavLink>
-          </div>
-        </Collapse>
       </div>
       <div className={styles.otherOptionsStatement}>
         <span className={styles.line}></span>

--- a/src/frontend/screens/Onboarding/walletSelection/screens/import/components/ImportAndCreateOptions/index.tsx
+++ b/src/frontend/screens/Onboarding/walletSelection/screens/import/components/ImportAndCreateOptions/index.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import { ImportAndCreateOptionsProps } from '../../types'
 import ImportOption from 'frontend/screens/Onboarding/components/importOption'
+import { NavLink } from 'react-router-dom'
 import { t } from 'i18next'
 import styles from './index.module.scss'
+import { Collapse, Images } from '@hyperplay/ui'
 import { ImportableBrowser } from '@hyperplay/utils'
 
 export default function ImportAndCreateOptions({
@@ -29,6 +31,46 @@ export default function ImportAndCreateOptions({
     <div className={styles.importAndCreateOptionsContainer}>
       <div className={styles.importOptionsContainer}>
         {importableBrowserOptions}
+      </div>
+      <div className={styles.actionsContainer}>
+        <Collapse title="Advanced Options">
+          <div className={styles.actionsCollapseContainer}>
+            <div className={styles.infoBox}>
+              <Images.Info
+                fill="var(--color-alert-400)"
+                className={styles.infoIcon}
+              />
+              <div className={styles.infoText}>
+                {t(
+                  'hyperplay.onboarding.walletSelection.screens.import.useRecoveryPhraseInfo',
+                  `This feature is recommended for advanced users and developers. Your secret recovery phrase is stored locally in MetaMask and never shared with HyperPlay.`
+                )}
+                <span
+                  onClick={() => window.api.openHyperplaySite()}
+                  className={styles.infoLink}
+                >
+                  {t(
+                    'hyperplay.onboarding.walletSelection.screens.import.learnMore',
+                    `Learn more.`
+                  )}
+                </span>
+              </div>
+            </div>
+            <NavLink to="/metamaskHome">
+              <ImportOption
+                override="recovery"
+                classNames={styles.importSecretRecoveryButton}
+                title={t(
+                  'hyperplay.onboarding.walletSelection.screens.import.useRecoveryPhrase',
+                  `Import Using Secret Recovery Phrase`
+                )}
+                onClick={async () => {
+                  handleImportMmExtensionClicked('SECRET_PHRASE')
+                }}
+              />
+            </NavLink>
+          </div>
+        </Collapse>
       </div>
       <div className={styles.otherOptionsStatement}>
         <span className={styles.line}></span>


### PR DESCRIPTION
Direct linking to SRP page results in a new wallet being created instead of importing from the SRP. Clicking create new wallet and then importing SRP starting from the first page works though.

![image](https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/assets/27568879/5e0784b3-8f19-4c66-8bb4-494b35349b39)
