### PR TITLE
[Fix] Compatibility with deprecated on topics and fix send request return for browser game provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperplay",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "private": true,
   "main": "build/main/main.js",
   "homepage": "./",

--- a/src/backend/proxy/providerPreload.ts
+++ b/src/backend/proxy/providerPreload.ts
@@ -17,7 +17,10 @@ const enabledTopics = [
   'connect',
   'message',
   'disconnect',
-  'chainChanged'
+  'chainChanged',
+  'close',
+  // deprecated
+  'networkChanged'
 ]
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -53,7 +56,7 @@ const sendRequest = async (...args: unknown[]) => {
   if (Object.hasOwn(result, 'error')) {
     throw result[0].error.message
   }
-  return result[0].result
+  return result
 }
 
 const sendAsyncRequest = async (payload: any, callback: JsonRpcCallback) => {

--- a/src/backend/proxy/providerPreload.ts
+++ b/src/backend/proxy/providerPreload.ts
@@ -52,11 +52,8 @@ const provRequest = async (args: RequestArguments) => {
 }
 
 const sendRequest = async (...args: unknown[]) => {
-  const result = (await ipcRenderer.invoke('sendRequest', args)) as object
-  if (Object.hasOwn(result, 'error')) {
-    throw result[0].error.message
-  }
-  return result
+  // send method return is unknown https://eips.ethereum.org/EIPS/eip-1193#send-deprecated
+  return ipcRenderer.invoke('sendRequest', args) as unknown
 }
 
 const sendAsyncRequest = async (payload: any, callback: JsonRpcCallback) => {


### PR DESCRIPTION
# Summary
Add deprecated provider on topics for backwards compatibility. Return result directly from send

# Testing
https://app.qase.io/project/HC?suite=61&case=346&previewMode=modal