### PR TITLE
tech(auth): close sign in modal after connection event is triggered

### DIFF
--- a/src/frontend/components/UI/AuthModal/index.tsx
+++ b/src/frontend/components/UI/AuthModal/index.tsx
@@ -74,6 +74,7 @@ const AuthModal = () => {
           authState.closeSignInModal()
           break
         case 'auth:accountConnected':
+          authState.closeSignInModal()
           window.api.authConnected()
           await authSession.invalidateQuery()
           break
@@ -118,6 +119,7 @@ const AuthModal = () => {
         // TODO: need to clear cookie in auth modal to send back to first page
       }
     }
+
     const removeHandleAuthEvent = window.api.handleAuthEvent(handleAuthEvent)
 
     return () => {


### PR DESCRIPTION
Right now is not the smoothest transition since you can see the updated UI for like half a second but it's a good 1 line improvement.

