### PR TITLE
[Tech] Fix channel logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperplay",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "private": true,
   "main": "build/main/main.js",
   "homepage": "./",

--- a/src/backend/storeManagers/hyperplay/library.ts
+++ b/src/backend/storeManagers/hyperplay/library.ts
@@ -206,10 +206,13 @@ export async function listUpdateableGames(): Promise<string[]> {
 
     if (val.channels && val.install.channelName && val.install.platform) {
       if (!Object.hasOwn(val.channels, val.install.channelName)) {
-        console.error(`
+        logError(
+          `
         Cannot find installed channel name in channels. 
         The channel name may have been changed by the remote.
-        To continue to receive game updates, uninstall and reinstall this game: ${val.title}`)
+        To continue to receive game updates, uninstall and reinstall this game: ${val.title}`,
+          LogPrefix.HyperPlay
+        )
       }
       if (
         // games installed before 0.5.0 used gameInfo.version for install.version

--- a/src/backend/storeManagers/hyperplay/library.ts
+++ b/src/backend/storeManagers/hyperplay/library.ts
@@ -213,6 +213,7 @@ export async function listUpdateableGames(): Promise<string[]> {
         To continue to receive game updates, uninstall and reinstall this game: ${val.title}`,
           LogPrefix.HyperPlay
         )
+        return
       }
       if (
         // games installed before 0.5.0 used gameInfo.version for install.version


### PR DESCRIPTION
# Summary
- change `console.error` to `logError` so that error message can be seen in production for channel names that were changed or removed
- early return so that library refresh does not get stuck if a library game is in this state