### PR TITLE
[Fix] add try catch to close overlay

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -888,7 +888,11 @@ async function callRunner(
     })
 
     child.on('close', (code, signal) => {
-      if (shouldOpenOverlay) hpOverlay?.closeOverlay()
+      try {
+        if (shouldOpenOverlay) hpOverlay?.closeOverlay()
+      } catch (err) {
+        logError(`Error closing overlay: ${err}`, LogPrefix.HyperPlay)
+      }
       errorHandler({
         error: `${stdout.join().concat(stderr.join())}`,
         logPath: options?.logFile,


### PR DESCRIPTION
# Summary
Previously, there was a bug where closing the overlay and then the game would throw when `hpOverlay?.closeOverlay()` was called in `child.on('close'`. This would cause play sessions to not be posted correctly on game close. This could happen if the user pressed alt+f4 twice with the overlay over the game for instance.

This PR adds a try catch to the close overlay call so that the rest of the 'launch' handler will execute under these circumstances.
