### PR TITLE
[Fix] Decimals null check in useGetRewards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperplay",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "private": true,
   "main": "build/main/main.js",
   "homepage": "./",

--- a/src/frontend/hooks/useGetRewards.ts
+++ b/src/frontend/hooks/useGetRewards.ts
@@ -24,7 +24,11 @@ export function useGetRewards(questId: number | null) {
       }
       for (const reward_i of questRewards) {
         let numToClaim: string | undefined = undefined
-        if (reward_i.amount_per_user && reward_i.decimals) {
+        if (
+          reward_i.amount_per_user &&
+          reward_i.decimals !== undefined &&
+          reward_i.decimals !== null
+        ) {
           numToClaim = getDecimalNumberFromAmount(
             reward_i.amount_per_user.toString(),
             reward_i.decimals


### PR DESCRIPTION
# Summary
- Fixes a bug where rewards with decimals = 0 won't display the amount to claim 