### PR TITLE
[FEAT] Show warning on close the app if a game is opened.

### DIFF
--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -612,7 +612,7 @@ class GlobalState extends PureComponent<Props> {
     storage.setItem('sidebar_collapsed', JSON.stringify(sidebarCollapsed))
 
     const pendingOps = libraryStatus.filter(
-      (game) => game.status !== 'playing' && game.status !== 'done'
+      (game) => game.status !== 'done'
     ).length
 
     if (pendingOps) {


### PR DESCRIPTION
This will show a warning dialog to the user if they try to close the app while a game is running. 
It is the same copy and options as we have for when a game is being downloaded.
We can trick this in the future if needed.


## To test
- Launch any game
- While the game is opened, try to close hyperplay
- A warning should appear.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
