### PR TITLE
[FIX] Show Wallet onboard when launching web3 game from GamePage

### DIFF
--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -873,14 +873,14 @@ export default observer(function GamePage(): JSX.Element | null {
         return window.api.kill(appName, gameInfo.runner)
       }
 
-          // ask to connect the wallet if its a web3 game
-    if (gameInfo.web3?.supported && !walletStore.isConnected) {
-      try {
-        await onboardingStore.startOnboarding()
-      } catch (e) {
-        console.error('User denied onboarding')
+      // ask to connect the wallet if its a web3 game
+      if (gameInfo.web3?.supported && !walletStore.isConnected) {
+        try {
+          await onboardingStore.startOnboarding()
+        } catch (e) {
+          console.error('User denied onboarding')
+        }
       }
-    }
 
       // open game
       await launch({

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -21,6 +21,8 @@ import { NavLink, useLocation, useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { UpdateComponent, SelectField } from 'frontend/components/UI'
+import walletStore from 'frontend/state/WalletState'
+import onboardingStore from 'frontend/store/OnboardingStore'
 
 import {
   AppPlatforms,
@@ -870,6 +872,15 @@ export default observer(function GamePage(): JSX.Element | null {
       if (isPlaying || isUpdating) {
         return window.api.kill(appName, gameInfo.runner)
       }
+
+          // ask to connect the wallet if its a web3 game
+    if (gameInfo.web3?.supported && !walletStore.isConnected) {
+      try {
+        await onboardingStore.startOnboarding()
+      } catch (e) {
+        console.error('User denied onboarding')
+      }
+    }
 
       // open game
       await launch({

--- a/yarn.lock
+++ b/yarn.lock
@@ -5293,6 +5293,13 @@ axios-retry@3.7.0:
     "@babel/runtime" "^7.15.4"
     is-retry-allowed "^2.2.0"
 
+axios-retry@^4.4.1:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-4.4.2.tgz#cef7c3eb1aa004f6a7e7b1a0918907b10a1986be"
+  integrity sha512-2fjo9uDNBQjX8+GMEGOFG5TrLMZ3QijjeRYcgBI2MhrsabnvcIAfLxxIhG7+CCD68vPEQY3IM2llV70ZsrqPvA==
+  dependencies:
+    is-retry-allowed "^2.2.0"
+
 axios@1.6.5:
   version "1.6.5"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.5.tgz#2c090da14aeeab3770ad30c3a1461bc970fb0cd8"


### PR DESCRIPTION
I noticed that the Wallet Onboard modal was showing up when launching games from the library but not showing up when launching games from the game page.
Since now most people are using the game page due to redirect I think this should be fixed.

![image](https://github.com/user-attachments/assets/61a7abd8-cf70-4d5b-bea3-71197f314879)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
