### PR TITLE
[FIX] Deal with Epic games listing from Quests Page

### DIFF
--- a/src/backend/api/library.ts
+++ b/src/backend/api/library.ts
@@ -150,3 +150,6 @@ export const checkHyperPlayAccessCode = async (
     accessCode
   )
 }
+
+export const getEpicListingUrl = async (appName: string) =>
+  ipcRenderer.invoke('getEpicListingUrl', appName)

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -54,7 +54,7 @@ import {
   WineCommandArgs,
   SteamRuntime
 } from 'common/types'
-import { execSync, spawn } from 'child_process'
+import { spawn } from 'child_process'
 import shlex from 'shlex'
 import { isOnline } from './online_monitor'
 import { showDialogBoxModalAuto } from './dialog/dialog'
@@ -1088,7 +1088,14 @@ async function stopChildProcesses(childPid: number) {
     return
   }
 
-  return execSync(`pkill -TERM -P ${childPid}`)
+  try {
+    return await spawnAsync('pkill', ['-TERM', '-P', childPid.toString()])
+  } catch (error) {
+    return logWarning(
+      `could not stop child processes from PID: ${childPid}. Maybe they were already stopped`,
+      LogPrefix.Backend
+    )
+  }
 }
 
 /**

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -126,10 +126,7 @@ import {
   getMainWindow,
   sendFrontendMessage
 } from './main_window'
-import {
-  addGameToLibrary,
-  getEpicListingUrl
-} from './storeManagers/hyperplay/library'
+import { addGameToLibrary } from './storeManagers/hyperplay/library'
 
 import * as HyperPlayGameManager from 'backend/storeManagers/hyperplay/games'
 import * as HyperPlayLibraryManager from 'backend/storeManagers/hyperplay/library'
@@ -184,7 +181,10 @@ import 'backend/ipcHandlers/quests'
 import 'backend/ipcHandlers/achievements'
 import 'backend/utils/auto_launch'
 import { hrtime } from 'process'
-import { getHyperPlayReleaseObject } from './storeManagers/hyperplay/utils'
+import {
+  getEpicListingUrl,
+  getHyperPlayReleaseObject
+} from './storeManagers/hyperplay/utils'
 import { postPlaySessionTime } from './utils/quests'
 
 import { gameIsEpicForwarderOnHyperPlay } from './utils/shouldOpenOverlay'

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -126,7 +126,10 @@ import {
   getMainWindow,
   sendFrontendMessage
 } from './main_window'
-import { addGameToLibrary } from './storeManagers/hyperplay/library'
+import {
+  addGameToLibrary,
+  getEpicListingUrl
+} from './storeManagers/hyperplay/library'
 
 import * as HyperPlayGameManager from 'backend/storeManagers/hyperplay/games'
 import * as HyperPlayLibraryManager from 'backend/storeManagers/hyperplay/library'
@@ -2017,6 +2020,10 @@ ipcMain.on('reloadApp', async () => {
 ipcMain.handle('addHyperplayGame', async (_e, projectId) => {
   await addGameToLibrary(projectId)
 })
+
+ipcMain.handle('getEpicListingUrl', async (_e, projectId) =>
+  getEpicListingUrl(projectId)
+)
 
 ipcMain.handle(
   'isGameHidden',

--- a/src/backend/storeManagers/hyperplay/library.ts
+++ b/src/backend/storeManagers/hyperplay/library.ts
@@ -18,7 +18,6 @@ import {
 } from './utils'
 import { getGameInfo as getGamesGameInfo } from './games'
 import { getValistListingApiUrl, qaToken } from 'backend/constants'
-import { ProjectMetaInterface } from '@valist/sdk/dist/typesShared'
 
 export async function addGameToLibrary(projectId: string) {
   const currentLibrary = hpLibraryStore.get('games', [])
@@ -45,38 +44,6 @@ export async function addGameToLibrary(projectId: string) {
   const data = res.data
   const gameInfo = getGameInfoFromHpRelease(data)
   hpLibraryStore.set('games', [...currentLibrary, gameInfo])
-}
-
-// hit the valist api and get the info if the game is a epic listing
-export async function getEpicListingUrl(projectId: string): Promise<string> {
-  const listingUrl = getValistListingApiUrl(projectId)
-
-  try {
-    const getConfig =
-      qaToken !== '' ? { headers: { Authorization: `Bearer ${qaToken}` } } : {}
-    const res = await axios.get<HyperPlayRelease>(listingUrl, getConfig)
-
-    if (res.status !== 200) {
-      logError(`Error when trying to get listing info ${res}`)
-      return ''
-    }
-
-    const data = res.data
-    const { epic_game_url, launch_epic } =
-      data.project_meta as ProjectMetaInterface
-
-    if (
-      !!launch_epic &&
-      !!epic_game_url &&
-      epic_game_url.startsWith('https://store.epicgames.com/')
-    ) {
-      return epic_game_url
-    }
-    return ''
-  } catch (error) {
-    logError(`Error when trying to get listing info: ${error}`)
-    return ''
-  }
 }
 
 export const getInstallInfo = async (

--- a/src/backend/storeManagers/hyperplay/library.ts
+++ b/src/backend/storeManagers/hyperplay/library.ts
@@ -18,6 +18,7 @@ import {
 } from './utils'
 import { getGameInfo as getGamesGameInfo } from './games'
 import { getValistListingApiUrl, qaToken } from 'backend/constants'
+import { ProjectMetaInterface } from '@valist/sdk/dist/typesShared'
 
 export async function addGameToLibrary(projectId: string) {
   const currentLibrary = hpLibraryStore.get('games', [])
@@ -44,6 +45,38 @@ export async function addGameToLibrary(projectId: string) {
   const data = res.data
   const gameInfo = getGameInfoFromHpRelease(data)
   hpLibraryStore.set('games', [...currentLibrary, gameInfo])
+}
+
+// hit the valist api and get the info if the game is a epic listing
+export async function getEpicListingUrl(projectId: string): Promise<string> {
+  const listingUrl = getValistListingApiUrl(projectId)
+
+  try {
+    const getConfig =
+      qaToken !== '' ? { headers: { Authorization: `Bearer ${qaToken}` } } : {}
+    const res = await axios.get<HyperPlayRelease>(listingUrl, getConfig)
+
+    if (res.status !== 200) {
+      logError(`Error when trying to get listing info ${res}`)
+      return ''
+    }
+
+    const data = res.data
+    const { epic_game_url, launch_epic } =
+      data.project_meta as ProjectMetaInterface
+
+    if (
+      !!launch_epic &&
+      !!epic_game_url &&
+      epic_game_url.startsWith('https://store.epicgames.com/')
+    ) {
+      return epic_game_url
+    }
+    return ''
+  } catch (error) {
+    logError(`Error when trying to get listing info: ${error}`)
+    return ''
+  }
 }
 
 export const getInstallInfo = async (

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -42,7 +42,13 @@ import {
   isFlatpak,
   isCLINoGui
 } from '../../constants'
-import { logError, logInfo, LogPrefix, logsDisabled } from '../../logger/logger'
+import {
+  logError,
+  logInfo,
+  LogPrefix,
+  logsDisabled,
+  logWarning
+} from '../../logger/logger'
 import {
   prepareLaunch,
   prepareWineLaunch,
@@ -299,7 +305,14 @@ export async function getExtraInfo(appName: string): Promise<ExtraInfo> {
 
   // if the API doesn't work, try graphql
   if (!extraData) {
-    extraData = await getExtraFromGraphql(namespace, slug)
+    try {
+      extraData = await getExtraFromGraphql(namespace, slug)
+    } catch (error) {
+      logWarning(
+        `Error hitting the EpicGraphQL API for ${title}`,
+        LogPrefix.Legendary
+      )
+    }
   }
 
   // if we have data, store it and return
@@ -307,7 +320,6 @@ export async function getExtraInfo(appName: string): Promise<ExtraInfo> {
     gameInfoStore.set(namespace, extraData)
     return extraData
   } else {
-    logError('Error Getting Info from Epic API', LogPrefix.Legendary)
     return {
       about: {
         description: '',

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -293,6 +293,7 @@ interface HyperPlayAsyncIPCFunctions {
   getPointsBalancesForProject: (
     projectId: string
   ) => Promise<{ pointsCollection: PointsCollection; balance: string }[]>
+  getEpicListingUrl: (appName: string) => Promise<string>
 }
 
 interface AsyncIPCFunctions extends HyperPlayAsyncIPCFunctions {

--- a/src/frontend/helpers/index.ts
+++ b/src/frontend/helpers/index.ts
@@ -149,13 +149,11 @@ export function getPlatformName(platform: string): string {
   }
 }
 
-// get last part of the url
 const getLastPartOfUrl = (url: string) => {
   return url.split('/').pop()
 }
 
 export const fetchEpicListing = async (projectId: string) => {
-  let appName: string | undefined
   const epicListingUrl = await window.api.getEpicListingUrl(projectId)
 
   if (!epicListingUrl) {
@@ -167,22 +165,21 @@ export const fetchEpicListing = async (projectId: string) => {
   }
 
   // filter libraryState using the epicListing url to get the appName
-  if (epicListingUrl) {
-    const lastPartOfHpUrl = getLastPartOfUrl(epicListingUrl)
-    appName = libraryState.epicLibrary.filter((g) => {
-      const game = JSON.parse(JSON.stringify(g)) as GameInfo
-      if (!game.store_url) return false
+  const lastPartOfHpUrl = getLastPartOfUrl(epicListingUrl)
+  const appName = libraryState.epicLibrary.filter((g) => {
+    const game = JSON.parse(JSON.stringify(g)) as GameInfo
+    if (!game.store_url) return false
 
-      const lastPartOfEpicUrl = getLastPartOfUrl(game.store_url)
+    const lastPartOfEpicUrl = getLastPartOfUrl(game.store_url)
 
-      if (!lastPartOfEpicUrl || !lastPartOfHpUrl) return false
+    if (!lastPartOfEpicUrl || !lastPartOfHpUrl) return false
 
-      // test the last part of the URL from the start since sometimes
-      // it might includes some numbers at the end but they are the same listing.
-      // in the future might need some adjustments depending on the game, so far work with Apeiron and Moonray
-      return lastPartOfHpUrl.startsWith(lastPartOfEpicUrl)
-    })[0].app_name
-  }
+    // test the last part of the URL from the start since sometimes
+    // it might includes some numbers at the end but they are the same listing.
+    // in the future might need some adjustments depending on the game,
+    // so far work with Apeiron and Moonray
+    return lastPartOfHpUrl.startsWith(lastPartOfEpicUrl)
+  })[0].app_name
 
   return { appName, epicListingUrl }
 }

--- a/src/frontend/helpers/index.ts
+++ b/src/frontend/helpers/index.ts
@@ -11,6 +11,7 @@ import { GogInstallInfo } from 'common/types/gog'
 
 import { install, launch, repair, updateGame } from './library'
 import * as fileSize from 'filesize'
+import libraryState from 'frontend/state/libraryState'
 
 const notify = (args: { title: string; body: string }) =>
   window.api.notify(args)
@@ -146,6 +147,40 @@ export function getPlatformName(platform: string): string {
     default:
       return platform
   }
+}
+
+// get last part of the url
+const getLastPartOfUrl = (url: string) => {
+  return url.split('/').pop()
+}
+
+export const fetchEpicListing = async (projectId: string) => {
+  let appName: string | undefined
+  const epicListingUrl = await window.api.getEpicListingUrl(projectId)
+
+  if (!epicListingUrl || !libraryState.epicLibrary) {
+    return { appName: '', epicListingUrl: '' }
+  }
+
+  // filter libraryState using the epicListing url to get the appName
+  if (epicListingUrl) {
+    const lastPartOfHpUrl = getLastPartOfUrl(epicListingUrl)
+    appName = libraryState.epicLibrary.filter((g) => {
+      const game = JSON.parse(JSON.stringify(g)) as GameInfo
+      if (!game.store_url) return false
+
+      const lastPartOfEpicUrl = getLastPartOfUrl(game.store_url)
+
+      if (!lastPartOfEpicUrl || !lastPartOfHpUrl) return false
+
+      // test the last part of the URL from the start since sometimes
+      // it might includes some numbers at the end but they are the same listing.
+      // in the future might need some adjustments depending on the game, so far work with Apeiron and Moonray
+      return lastPartOfHpUrl.startsWith(lastPartOfEpicUrl)
+    })[0].app_name
+  }
+
+  return { appName, epicListingUrl }
 }
 
 export {

--- a/src/frontend/helpers/index.ts
+++ b/src/frontend/helpers/index.ts
@@ -158,8 +158,12 @@ export const fetchEpicListing = async (projectId: string) => {
   let appName: string | undefined
   const epicListingUrl = await window.api.getEpicListingUrl(projectId)
 
-  if (!epicListingUrl || !libraryState.epicLibrary) {
+  if (!epicListingUrl) {
     return { appName: '', epicListingUrl: '' }
+  }
+
+  if (!libraryState.epicLibrary.length) {
+    return { appName: '', epicListingUrl }
   }
 
   // filter libraryState using the epicListing url to get the appName

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -21,6 +21,8 @@ import { NavLink, useLocation, useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { UpdateComponent, SelectField } from 'frontend/components/UI'
+import walletStore from 'frontend/state/WalletState'
+import onboardingStore from 'frontend/store/OnboardingStore'
 
 import {
   AppPlatforms,
@@ -869,6 +871,15 @@ export default observer(function GamePage(): JSX.Element | null {
     return async () => {
       if (isPlaying || isUpdating) {
         return window.api.kill(appName, gameInfo.runner)
+      }
+
+      // ask to connect the wallet if its a web3 game
+      if (gameInfo.web3?.supported && !walletStore.isConnected) {
+        try {
+          await onboardingStore.startOnboarding()
+        } catch (e) {
+          console.error('User denied onboarding')
+        }
       }
 
       // open game

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -69,10 +69,16 @@ import DMQueueState from 'frontend/state/DMQueueState'
 import { useEstimatedUncompressedSize } from 'frontend/hooks/useEstimatedUncompressedSize'
 import authState from 'frontend/state/authState'
 
+type locationState = {
+  fromDM?: boolean
+  gameInfo: GameInfo
+  fromQuests?: boolean
+}
+
 export default observer(function GamePage(): JSX.Element | null {
   const { appName, runner } = useParams() as { appName: string; runner: Runner }
   const location = useLocation() as {
-    state: { fromDM?: boolean; gameInfo: GameInfo; fromQuests?: boolean }
+    state: locationState
   }
   const { t } = useTranslation('gamepage')
   const { t: t2 } = useTranslation()
@@ -959,15 +965,15 @@ function getCurrentProgress(
       }`
 }
 
-function getBackRoute(locationState?: { fromDM?: boolean; fromQuests?: boolean }) {
+function getBackRoute(locationState?: locationState) {
   if (!locationState) {
-    return '/library';
+    return '/library'
   }
   if (locationState.fromDM) {
-    return '/download-manager';
+    return '/download-manager'
   }
   if (locationState.fromQuests) {
-    return '/quests';
+    return '/quests'
   }
-  return '/library';
+  return '/library'
 }

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -72,7 +72,7 @@ import authState from 'frontend/state/authState'
 export default observer(function GamePage(): JSX.Element | null {
   const { appName, runner } = useParams() as { appName: string; runner: Runner }
   const location = useLocation() as {
-    state: { fromDM: boolean; gameInfo: GameInfo }
+    state: { fromDM?: boolean; gameInfo: GameInfo; fromQuests?: boolean }
   }
   const { t } = useTranslation('gamepage')
   const { t: t2 } = useTranslation()
@@ -137,7 +137,7 @@ export default observer(function GamePage(): JSX.Element | null {
     gameInfo.runner !== 'sideload' && gameInfo.thirdPartyManagedApp === 'Origin'
   const isOffline = connectivity.status !== 'online'
 
-  const backRoute = location.state?.fromDM ? '/download-manager' : '/library'
+  const backRoute = getBackRoute(location.state)
 
   const storage: Storage = window.localStorage
 
@@ -957,4 +957,17 @@ function getCurrentProgress(
           ? `${percent.toFixed(2)}% [${bytes} MB]  ${eta ? `ETA: ${eta}` : ''}`
           : '...'
       }`
+}
+
+function getBackRoute(locationState?: { fromDM?: boolean; fromQuests?: boolean }) {
+  if (!locationState) {
+    return '/library';
+  }
+  if (locationState.fromDM) {
+    return '/download-manager';
+  }
+  if (locationState.fromQuests) {
+    return '/quests';
+  }
+  return '/library';
 }

--- a/src/frontend/screens/Quests/components/QuestDetailsViewPlay/index.tsx
+++ b/src/frontend/screens/Quests/components/QuestDetailsViewPlay/index.tsx
@@ -36,6 +36,14 @@ export function QuestDetailsViewPlayWrapper({
 
   const navigateToGame = useMutation({
     mutationFn: async (appName: string) => {
+      const epicListingUrl = await window.api.getEpicListingUrl(appName)
+
+      console.log('epicListingUrl', epicListingUrl)
+
+      if (epicListingUrl) {
+        return navigate(`/store-page?store-url=${epicListingUrl}`)
+      }
+
       await window.api.addHyperplayGame(appName)
       const gameInfo = await getGameInfo(appName, 'hyperplay')
       navigate(`/gamepage/hyperplay/${appName}`, {

--- a/src/frontend/screens/Quests/components/QuestDetailsViewPlay/index.tsx
+++ b/src/frontend/screens/Quests/components/QuestDetailsViewPlay/index.tsx
@@ -57,7 +57,6 @@ export function QuestDetailsViewPlayWrapper({
           )
         })
         .catch(async () => {
-          console.log('Game not found in library, adding to library')
           // if hyperplay game, add to library and navigate to game page
           if (runner === 'hyperplay') {
             await window.api.addHyperplayGame(appName)

--- a/src/frontend/screens/Quests/components/QuestDetailsViewPlay/index.tsx
+++ b/src/frontend/screens/Quests/components/QuestDetailsViewPlay/index.tsx
@@ -40,17 +40,25 @@ export function QuestDetailsViewPlayWrapper({
       const { appName: epicAppName, epicListingUrl } = await fetchEpicListing(
         appName
       )
-      const runner: Runner = epicListingUrl ? 'legendary' : 'hyperplay'
+
+      let runner: Runner = 'hyperplay'
+      let name = appName
+      if (epicListingUrl){
+        runner = 'legendary'
+        if (epicAppName) {
+          name = epicAppName
+        }
+      }
 
       // check for gameinfo to see if it is on the library
-      return getGameInfo(epicAppName || appName, runner)
+      return getGameInfo(name, runner)
         .then((res) => {
           if (!res) {
             throw new Error('Game not found in library')
           }
-
+          
           return navigate(
-            `/gamepage/${runner}/${epicAppName ? epicAppName : appName}`,
+            `/gamepage/${runner}/${name}`,
             {
               state: { gameInfo: res, fromDM: false }
             }
@@ -59,11 +67,11 @@ export function QuestDetailsViewPlayWrapper({
         .catch(async () => {
           // if hyperplay game, add to library and navigate to game page
           if (runner === 'hyperplay') {
-            await window.api.addHyperplayGame(appName)
-            const gameInfo = await getGameInfo(appName, runner)
+            await window.api.addHyperplayGame(name)
+            const gameInfo = await getGameInfo(name, runner)
 
-            return navigate(`/gamepage/hyperplay/${appName}`, {
-              state: { gameInfo, fromDM: false }
+            return navigate(`/gamepage/hyperplay/${name}`, {
+              state: { gameInfo, fromDM: false}
             })
           }
           // if epic game, open in epic store

--- a/src/frontend/screens/Quests/components/QuestDetailsViewPlay/index.tsx
+++ b/src/frontend/screens/Quests/components/QuestDetailsViewPlay/index.tsx
@@ -43,7 +43,7 @@ export function QuestDetailsViewPlayWrapper({
 
       let runner: Runner = 'hyperplay'
       let name = appName
-      if (epicListingUrl){
+      if (epicListingUrl) {
         runner = 'legendary'
         if (epicAppName) {
           name = epicAppName
@@ -56,13 +56,10 @@ export function QuestDetailsViewPlayWrapper({
           if (!res) {
             throw new Error('Game not found in library')
           }
-          
-          return navigate(
-            `/gamepage/${runner}/${name}`,
-            {
-              state: { gameInfo: res, fromDM: false }
-            }
-          )
+
+          return navigate(`/gamepage/${runner}/${name}`, {
+            state: { gameInfo: res, fromQuests: true }
+          })
         })
         .catch(async () => {
           // if hyperplay game, add to library and navigate to game page
@@ -71,7 +68,7 @@ export function QuestDetailsViewPlayWrapper({
             const gameInfo = await getGameInfo(name, runner)
 
             return navigate(`/gamepage/hyperplay/${name}`, {
-              state: { gameInfo, fromDM: false}
+              state: { gameInfo, fromQuests: true }
             })
           }
           // if epic game, open in epic store


### PR DESCRIPTION
FIX #990 by  adding some methods to get the epic url from the API and checking it with the epic games on the use library then navigating either to the library page (when the game is on the library) or to the epic games store page.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
