### PR TITLE
[Fix] no quests message

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -682,6 +682,10 @@
         "View Game": "View Game"
     },
     "quests": {
+        "noneFound": {
+            "message": "There were no quests found.",
+            "title": "No Quests Found."
+        },
         "playstreak": {
             "signInWarning": {
                 "client": "You are currently not logged in, play streak progress will not be tracked. Please login to HyperPlay via the top-right dropdown to track progress.",

--- a/src/frontend/screens/Quests/components/QuestsSummaryTableWrapper/index.tsx
+++ b/src/frontend/screens/Quests/components/QuestsSummaryTableWrapper/index.tsx
@@ -103,8 +103,8 @@ export function QuestsSummaryTableWrapper({
         ]
       }
       messageModalProps={{
-        title: 'msg modal title',
-        message: 'msg modal msg'
+        title: 'No Quests Found.',
+        message: 'There were no quests found.'
       }}
       pageTitle={t('quests.quests', 'Quests')}
       className={styles.tableContainer}

--- a/src/frontend/screens/Quests/components/QuestsSummaryTableWrapper/index.tsx
+++ b/src/frontend/screens/Quests/components/QuestsSummaryTableWrapper/index.tsx
@@ -103,8 +103,8 @@ export function QuestsSummaryTableWrapper({
         ]
       }
       messageModalProps={{
-        title: 'No Quests Found.',
-        message: 'There were no quests found.'
+        title: t('quests.noneFound.title', 'No Quests Found.'),
+        message: t('quests.noneFound.message', 'There were no quests found.')
       }}
       pageTitle={t('quests.quests', 'Quests')}
       className={styles.tableContainer}


### PR DESCRIPTION
# Summary
- if the GET quests request fails, this message modal will show
