### PR TITLE
[Fix] erc1155 numClaimsLeft

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -915,8 +915,11 @@ export interface Reward {
   name: string
   contract_address: `0x${string}`
   decimals: number | null
-  /* eslint-disable-next-line */
-  token_ids: { amount_per_user: string; token_id: number }[]
+  token_ids: {
+    amount_per_user: string
+    token_id: number
+    numClaimsLeft: string
+  }[]
   image_url: string
   numClaimsLeft: string
 }

--- a/src/frontend/hooks/useGetRewards.ts
+++ b/src/frontend/hooks/useGetRewards.ts
@@ -45,14 +45,31 @@ export function useGetRewards(questId: number | null) {
           ).toString()
         }
 
-        const questReward_i: QuestReward = {
-          title: reward_i.name,
-          imageUrl: reward_i.image_url,
-          chainName: getRewardCategory(reward_i, t),
-          numToClaim,
-          numOfClaimsLeft: reward_i.numClaimsLeft
+        if (
+          reward_i.reward_type === 'ERC1155' &&
+          reward_i.token_ids &&
+          reward_i.token_ids.length
+        ) {
+          for (const token_i of reward_i.token_ids) {
+            const questReward_i: QuestReward = {
+              title: reward_i.name,
+              imageUrl: reward_i.image_url,
+              chainName: getRewardCategory(reward_i, t),
+              numToClaim: token_i.amount_per_user,
+              numOfClaimsLeft: token_i.numClaimsLeft
+            }
+            rewards.push(questReward_i)
+          }
+        } else {
+          const questReward_i: QuestReward = {
+            title: reward_i.name,
+            imageUrl: reward_i.image_url,
+            chainName: getRewardCategory(reward_i, t),
+            numToClaim,
+            numOfClaimsLeft: reward_i.numClaimsLeft
+          }
+          rewards.push(questReward_i)
         }
-        rewards.push(questReward_i)
       }
       return rewards
     },


### PR DESCRIPTION
# Summary
Fix `numClaimsLeft` for erc1155 rewards

# Testing
Check xociety crates (ERC1155). number of claims left should be 10000
Bushi (ERC721) should still read 125
Other rewards (ERC20) should still show correctly if assets have been deposited