### PR TITLE
[CI] disable e2e tests

### DIFF
--- a/.github/workflows/test-e2e-dev.yml
+++ b/.github/workflows/test-e2e-dev.yml
@@ -13,6 +13,7 @@ env:
   RUDDERSTACK_CLIENT_ID: ${{ secrets.RUDDERSTACK_CLIENT_ID }}
 
 jobs:
+  if: false
   linux-dev:
     runs-on: ubuntu-latest
     concurrency:

--- a/.github/workflows/test-e2e-packaged.yml
+++ b/.github/workflows/test-e2e-packaged.yml
@@ -14,6 +14,7 @@ env:
   RUDDERSTACK_CLIENT_ID: ${{ secrets.RUDDERSTACK_CLIENT_ID }}
 
 jobs:
+  if: false
   linux-packaged:
     runs-on: ubuntu-latest
     concurrency:


### PR DESCRIPTION
# Summary
The e2e tests are notoriously flaky, time-consuming/difficult to write, and haven't caught many bugs to date. Let's disable them for now until this implementation is more robust and the developer experience is acceptable.