### PR TITLE
[FIX] HyperPlay fails if the game default channel is not expected

### DIFF
--- a/src/backend/downloadmanager/downloadqueue.ts
+++ b/src/backend/downloadmanager/downloadqueue.ts
@@ -133,7 +133,11 @@ async function addToQueue(element: DMQueueElement) {
   } else {
     const installInfo = await libraryManagerMap[
       element.params.runner
-    ].getInstallInfo(element.params.appName, element.params.platformToInstall)
+    ].getInstallInfo(
+      element.params.appName,
+      element.params.platformToInstall,
+      element.params.channelName ?? 'main'
+    )
 
     element.params.size = installInfo?.manifest?.download_size
       ? getFileSize(installInfo?.manifest?.download_size)

--- a/src/backend/storeManagers/hyperplay/library.ts
+++ b/src/backend/storeManagers/hyperplay/library.ts
@@ -16,7 +16,7 @@ import {
   sanitizeVersion,
   refreshGameInfoFromHpRelease
 } from './utils'
-import { getGameInfo as getGamesGameInfo } from './games'
+import { getGameInfo } from './games'
 import { getValistListingApiUrl, qaToken } from 'backend/constants'
 
 export async function addGameToLibrary(projectId: string) {
@@ -51,16 +51,25 @@ export const getInstallInfo = async (
   platformToInstall: InstallPlatform,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   lang = 'en',
-  channelNameToInstall = 'main'
+  channelNameToInstall: string
 ): Promise<HyperPlayInstallInfo | undefined> => {
-  const gameInfo = getGamesGameInfo(appName)
+  const gameInfo = getGameInfo(appName)
+
+  if (!channelNameToInstall) {
+    logWarning(
+      'channelNameToInstall is undefined in getInstallInfo, probably a false positive.',
+      LogPrefix.HyperPlay
+    )
+    return
+  }
 
   if (
     gameInfo.channels === undefined ||
     gameInfo.channels[channelNameToInstall].release_meta === undefined
   ) {
-    console.error(
-      'Channels or Release Meta were undefined in getInstallInfo for HyperPlay Library Manager'
+    logError(
+      'Channels or Release Meta were undefined in getInstallInfo for HyperPlay Library Manager',
+      LogPrefix.HyperPlay
     )
     return undefined
   }
@@ -77,8 +86,9 @@ export const getInstallInfo = async (
   const info = releaseMeta.platforms[requestedPlatform]
 
   if (info === undefined) {
-    console.error(
-      'Info was undefined in getInstallInfo for HyperPlay Library Manager'
+    logError(
+      'Info was undefined in getInstallInfo for HyperPlay Library Manager',
+      LogPrefix.HyperPlay
     )
     return undefined
   }
@@ -168,16 +178,6 @@ export async function refresh() {
     }
   }
   return defaultExecResult
-}
-
-export function getGameInfo(
-  /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-  appName: string,
-  /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-  forceReload?: boolean
-): GameInfo | undefined {
-  logWarning(`getGameInfo not implemented on HyperPlay Library Manager`)
-  return undefined
 }
 
 /* returns array of app names (i.e. _id's) for game releases that are out of date

--- a/src/backend/storeManagers/hyperplay/library.ts
+++ b/src/backend/storeManagers/hyperplay/library.ts
@@ -16,7 +16,7 @@ import {
   sanitizeVersion,
   refreshGameInfoFromHpRelease
 } from './utils'
-import { getGameInfo } from './games'
+import { getGameInfo as getGamesGameInfo } from './games'
 import { getValistListingApiUrl, qaToken } from 'backend/constants'
 
 export async function addGameToLibrary(projectId: string) {
@@ -51,9 +51,9 @@ export const getInstallInfo = async (
   platformToInstall: InstallPlatform,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   lang = 'en',
-  channelNameToInstall: string
+  channelNameToInstall?: string
 ): Promise<HyperPlayInstallInfo | undefined> => {
-  const gameInfo = getGameInfo(appName)
+  const gameInfo = getGamesGameInfo(appName)
 
   if (!channelNameToInstall) {
     logWarning(
@@ -145,6 +145,10 @@ export function refreshHPGameInfo(appId: string, data: HyperPlayRelease) {
 const defaultExecResult = {
   stderr: '',
   stdout: ''
+}
+
+export function getGameInfo(appName: string): GameInfo | undefined {
+  return getGamesGameInfo(appName)
 }
 
 /**

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -224,7 +224,7 @@ export default observer(function GamePage(): JSX.Element | null {
           !notInstallable &&
           !isOffline
         ) {
-          getInstallInfo(appName, runner, installPlatform)
+          getInstallInfo(appName, runner, installPlatform, channelName)
             .then((info) => {
               if (!info) {
                 throw 'Cannot get game info'


### PR DESCRIPTION
Should fix an issue where the Game fails to download or is stuck in the queue because the default channel is different from  `main`. 
So it was defaulting to `main` on `addDMToQueue` and then `release_meta` was coming as `undefined`.

Tested installing games that has only one main channel like Darkthrone, games that has two channels like Bushi and Code: Havoc that has only the Alpha channel and no main channel.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
