### PR TITLE
[Fix] hide, unhide, favorite, and unfavorite game

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -485,7 +485,7 @@ export type RecentGame = {
   title: string
 }
 
-export type HiddenGame = RecentGame
+export type HiddenGame = { appName: string }
 
 export type FavouriteGame = HiddenGame
 

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -249,17 +249,13 @@ const GameCard = ({
     {
       // hide
       label: t('button.hide_game', 'Hide Game'),
-      onClick: handleClickStopBubbling(() =>
-        libraryState.hiddenGames?.add(appName, title)
-      ),
+      onClick: handleClickStopBubbling(() => libraryState.hideGame(appName)),
       show: !isHiddenGame
     },
     {
       // unhide
       label: t('button.unhide_game', 'Unhide Game'),
-      onClick: handleClickStopBubbling(() =>
-        libraryState.hiddenGames?.remove(appName)
-      ),
+      onClick: handleClickStopBubbling(() => libraryState.unhideGame(appName)),
       show: isHiddenGame
     },
     {

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -66,7 +66,6 @@ const GameCard = ({
   } = useContext(ContextProvider)
 
   const {
-    title,
     app_name: appName,
     runner,
     is_installed: isInstalled,
@@ -261,14 +260,14 @@ const GameCard = ({
     {
       label: t('button.favorites', 'Favorite'),
       onClick: handleClickStopBubbling(() =>
-        libraryState.favouriteGames?.add(appName, title)
+        libraryState.favouriteGame(appName)
       ),
       show: !favorited
     },
     {
       label: t('button.unfavorites', 'Unfavorite'),
       onClick: handleClickStopBubbling(() =>
-        libraryState.favouriteGames?.remove(appName)
+        libraryState.unfavouriteGame(appName)
       ),
       show: favorited
     },
@@ -337,12 +336,11 @@ const GameCard = ({
           imageUrl={gameInfo.art_square}
           favorited={favorited}
           onFavoriteClick={handleClickStopBubbling(() => {
-            if (!favorited)
-              libraryState.favouriteGames?.add(
-                gameInfo.app_name,
-                gameInfo.title
-              )
-            else libraryState.favouriteGames?.remove(gameInfo.app_name)
+            if (!favorited) {
+              libraryState.favouriteGame(gameInfo.app_name)
+            } else {
+              libraryState.unfavouriteGame(gameInfo.app_name)
+            }
           })}
           onDownloadClick={handleClickStopBubbling(buttonClick)}
           onRemoveFromQueueClick={handleClickStopBubbling(

--- a/src/frontend/screens/Library/components/GamesList/index.tsx
+++ b/src/frontend/screens/Library/components/GamesList/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { GameInfo, Runner } from 'common/types'
+import { GameInfo, HiddenGame, Runner } from 'common/types'
 import cx from 'classnames'
 import GameCard from '../GameCard'
 import { useTranslation } from 'react-i18next'
@@ -30,7 +30,7 @@ const GamesList = observer(
   }: Props): JSX.Element => {
     const { t } = useTranslation()
 
-    const favouriteGameMap = {}
+    const favouriteGameMap: Record<string, HiddenGame> = {}
     for (const game of libraryState.favouriteGames.list) {
       favouriteGameMap[game.appName] = game
     }
@@ -70,7 +70,7 @@ const GamesList = observer(
             }}
             isRecent={isRecent}
             gameInfo={gameInfo}
-            favorited={favouriteGameMap[app_name]}
+            favorited={!!favouriteGameMap[app_name]}
           />
         )
       })

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -188,27 +188,6 @@ class GlobalState extends PureComponent<Props> {
     this.setState({ showMetaMaskBrowserSidebarLinks: value })
   }
 
-  hideGame = (appNameToHide: string, appTitle: string) => {
-    if (libraryState.hiddenGames === undefined) return
-    const newHiddenGames = [
-      ...libraryState.hiddenGames.list,
-      { appName: appNameToHide, title: appTitle }
-    ]
-
-    libraryState.hiddenGames.list = newHiddenGames
-    configStore.set('games.hidden', newHiddenGames)
-  }
-
-  unhideGame = (appNameToUnhide: string) => {
-    if (libraryState.hiddenGames === undefined) return
-    const newHiddenGames = libraryState.hiddenGames.list.filter(
-      ({ appName }) => appName !== appNameToUnhide
-    )
-
-    libraryState.hiddenGames.list = newHiddenGames
-    configStore.set('games.hidden', newHiddenGames)
-  }
-
   addGameToFavourites = (appNameToAdd: string, appTitle: string) => {
     if (libraryState.favouriteGames === undefined) return
     const newFavouriteGames = [

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -188,29 +188,6 @@ class GlobalState extends PureComponent<Props> {
     this.setState({ showMetaMaskBrowserSidebarLinks: value })
   }
 
-  addGameToFavourites = (appNameToAdd: string, appTitle: string) => {
-    if (libraryState.favouriteGames === undefined) return
-    const newFavouriteGames = [
-      ...libraryState.favouriteGames.list.filter(
-        (fav) => fav.appName !== appNameToAdd
-      ),
-      { appName: appNameToAdd, title: appTitle }
-    ]
-
-    libraryState.favouriteGames.list = newFavouriteGames
-    configStore.set('games.favourites', newFavouriteGames)
-  }
-
-  removeGameFromFavourites = (appNameToRemove: string) => {
-    if (libraryState.favouriteGames === undefined) return
-    const newFavouriteGames = libraryState.favouriteGames.list.filter(
-      ({ appName }) => appName !== appNameToRemove
-    )
-
-    libraryState.favouriteGames.list = newFavouriteGames
-    configStore.set('games.favourites', newFavouriteGames)
-  }
-
   handleShowDialogModal = ({
     showDialog = true,
     ...options

--- a/src/frontend/state/__tests__/libraryState.test.ts
+++ b/src/frontend/state/__tests__/libraryState.test.ts
@@ -323,7 +323,7 @@ describe('libraryState.ts', () => {
     expect(libraryState.showRecentGames).toBe(false)
   })
 
-  test('hide game hides game', async () => {
+  test('hide and unhide a game', async () => {
     const game_a = getDummyGameInfo({
       title: 'a',
       is_installed: false,
@@ -351,6 +351,56 @@ describe('libraryState.ts', () => {
     libraryState.unhideGame(game_a.app_name)
     expect(libraryState.library.some((val) => val.app_name === game_a.app_name))
     expect(libraryState.library.some((val) => val.app_name === game_b.app_name))
+  })
+
+  test('favourite and unfavourite a game', async () => {
+    const game_a = getDummyGameInfo({
+      title: 'a',
+      is_installed: false,
+      runner: 'legendary'
+    })
+
+    const game_b = getDummyGameInfo({
+      title: 'b',
+      is_installed: false,
+      runner: 'legendary'
+    })
+    libraryState.epicLibrary = [game_a, game_b]
+
+    expect(
+      libraryState.favouriteGames.list.includes(
+        (val) => val.appName === game_a.app_name
+      ) === -1
+    )
+    expect(
+      libraryState.favouriteGames.list.includes(
+        (val) => val.appName === game_b.app_name
+      ) === -1
+    )
+
+    libraryState.favouriteGame(game_a.app_name)
+    expect(
+      libraryState.favouriteGames.list.findIndex(
+        (val) => val.appName === game_a.app_name
+      ) !== -1
+    )
+    expect(
+      libraryState.favouriteGames.list.findIndex(
+        (val) => val.appName === game_b.app_name
+      ) === -1
+    )
+
+    libraryState.unfavouriteGame(game_a.app_name)
+    expect(
+      libraryState.favouriteGames.list.findIndex(
+        (val) => val.appName === game_a.app_name
+      ) === -1
+    )
+    expect(
+      libraryState.favouriteGames.list.findIndex(
+        (val) => val.appName === game_b.app_name
+      ) === -1
+    )
   })
 })
 

--- a/src/frontend/state/__tests__/libraryState.test.ts
+++ b/src/frontend/state/__tests__/libraryState.test.ts
@@ -159,7 +159,7 @@ describe('libraryState.ts', () => {
     ]
 
     libraryState.favouriteGames = {
-      list: [{ appName: 'c', title: 'c' }],
+      list: [{ appName: 'c' }],
       add: () => {
         console.log('add')
       },
@@ -187,7 +187,7 @@ describe('libraryState.ts', () => {
     expect(libraryState.library.length).toBe(2)
     expect(libraryState.library[0].app_name).toBe('b')
     libraryState.hiddenGames = {
-      list: [{ appName: 'b', title: 'b' }],
+      list: [{ appName: 'b' }],
       add: () => {
         console.log('add')
       },

--- a/src/frontend/state/__tests__/libraryState.test.ts
+++ b/src/frontend/state/__tests__/libraryState.test.ts
@@ -368,12 +368,12 @@ describe('libraryState.ts', () => {
     libraryState.epicLibrary = [game_a, game_b]
 
     expect(
-      libraryState.favouriteGames.list.includes(
+      libraryState.favouriteGames.list.findIndex(
         (val) => val.appName === game_a.app_name
       ) === -1
     )
     expect(
-      libraryState.favouriteGames.list.includes(
+      libraryState.favouriteGames.list.findIndex(
         (val) => val.appName === game_b.app_name
       ) === -1
     )

--- a/src/frontend/state/__tests__/libraryState.test.ts
+++ b/src/frontend/state/__tests__/libraryState.test.ts
@@ -322,6 +322,36 @@ describe('libraryState.ts', () => {
     libraryState.libraryTopSection = 'disabled'
     expect(libraryState.showRecentGames).toBe(false)
   })
+
+  test('hide game hides game', async () => {
+    const game_a = getDummyGameInfo({
+      title: 'a',
+      is_installed: false,
+      runner: 'legendary'
+    })
+
+    const game_b = getDummyGameInfo({
+      title: 'b',
+      is_installed: false,
+      runner: 'legendary'
+    })
+    libraryState.epicLibrary = [game_a, game_b]
+
+    expect(libraryState.library.some((val) => val.app_name === game_a.app_name))
+    expect(libraryState.library.some((val) => val.app_name === game_b.app_name))
+
+    libraryState.hideGame(game_a.app_name)
+    expect(
+      libraryState.library.findIndex(
+        (val) => val.app_name === game_a.app_name
+      ) === -1
+    )
+    expect(libraryState.library.some((val) => val.app_name === game_b.app_name))
+
+    libraryState.unhideGame(game_a.app_name)
+    expect(libraryState.library.some((val) => val.app_name === game_a.app_name))
+    expect(libraryState.library.some((val) => val.app_name === game_b.app_name))
+  })
 })
 
 export {}

--- a/src/frontend/state/libraryState.ts
+++ b/src/frontend/state/libraryState.ts
@@ -37,8 +37,8 @@ export class GameCollectionClass implements GameCollection {
     makeAutoObservable(this)
   }
 
-  add(appNameToAdd: string, appTitle: string) {
-    this.list.push({ appName: appNameToAdd, title: appTitle })
+  add(appNameToAdd: string) {
+    this.list.push({ appName: appNameToAdd })
   }
   remove(appNameToRemove: string) {
     this.list = this.list.filter((val) => val.appName !== appNameToRemove)
@@ -460,6 +460,26 @@ class LibraryState {
     return (
       this.hyperPlayLibrary.filter((val) => appNames.includes(val.app_name))
         .length > 0
+    )
+  }
+
+  hideGame(appName: string) {
+    if (this.hiddenGames === undefined) return
+
+    this.hiddenGames.add(appName, '')
+    configStore.set(
+      'games.hidden',
+      JSON.parse(JSON.stringify(this.hiddenGames.list))
+    )
+  }
+
+  unhideGame(appNameToUnhide: string) {
+    if (this.hiddenGames === undefined) return
+
+    this.hiddenGames.remove(appNameToUnhide)
+    configStore.set(
+      'games.hidden',
+      JSON.parse(JSON.stringify(this.hiddenGames.list))
     )
   }
 }

--- a/src/frontend/state/libraryState.ts
+++ b/src/frontend/state/libraryState.ts
@@ -38,6 +38,10 @@ export class GameCollectionClass implements GameCollection {
   }
 
   add(appNameToAdd: string) {
+    if (this.list.findIndex((val) => val.appName === appNameToAdd) !== -1) {
+      console.log('game has already been added to this list')
+      return
+    }
     this.list.push({ appName: appNameToAdd })
   }
   remove(appNameToRemove: string) {
@@ -152,6 +156,7 @@ class LibraryState {
     this.refreshSideloadedLibrary()
 
     this.hiddenGames.list = configStore.get('games.hidden', [])
+    this.favouriteGames.list = configStore.get('games.favourites', [])
 
     this.refreshing = false
     this.refreshingInTheBackground = true
@@ -473,13 +478,33 @@ class LibraryState {
     )
   }
 
-  unhideGame(appNameToUnhide: string) {
+  unhideGame(appName: string) {
     if (this.hiddenGames === undefined) return
 
-    this.hiddenGames.remove(appNameToUnhide)
+    this.hiddenGames.remove(appName)
     configStore.set(
       'games.hidden',
       JSON.parse(JSON.stringify(this.hiddenGames.list))
+    )
+  }
+
+  favouriteGame(appName: string) {
+    if (this.favouriteGames === undefined) return
+
+    this.favouriteGames.add(appName, '')
+    configStore.set(
+      'games.favourites',
+      JSON.parse(JSON.stringify(this.favouriteGames.list))
+    )
+  }
+
+  unfavouriteGame(appName: string) {
+    if (this.favouriteGames === undefined) return
+
+    this.favouriteGames.remove(appName)
+    configStore.set(
+      'games.favourites',
+      JSON.parse(JSON.stringify(this.favouriteGames.list))
     )
   }
 }


### PR DESCRIPTION
# Summary
This PR
- fixes hide, unhide, favorite and unfavorite
  - previously favorite and unhide would not work on refresh or app restart. taking any action would revert the hidden game as well
- moves this functionality into library state and adds a test for it