### PR TITLE
[FIX] Don't show Game Settings for Browser games on game card

### DIFF
--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -165,7 +165,8 @@ const GameCard = ({
   }
 
   const isHiddenGame = libraryState.isGameHidden(appName)
-  const isBrowserGame = installPlatform === 'Browser'
+  const isBrowserGame =
+    installPlatform === 'Browser' || installPlatform === 'web'
 
   const onUninstallClick = function () {
     setShowUninstallModal(true)


### PR DESCRIPTION
Small fix to a bug I just found where we can access the game settings for Browser games.

Before:
![image](https://github.com/user-attachments/assets/92d91f9c-5bed-4f94-9a5d-901182ae6463)

After:
![image](https://github.com/user-attachments/assets/5abfcc51-0724-47af-bb0e-b03c6e41d6b3)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
