### PR TITLE
tech(quest): handle error in getting external tasks claims data

### DIFF
--- a/src/frontend/hooks/useGetRewards.ts
+++ b/src/frontend/hooks/useGetRewards.ts
@@ -36,13 +36,19 @@ export function useGetRewards(questId: number | null) {
         }
 
         if (reward_i.reward_type === 'EXTERNAL-TASKS') {
-          const taskAmountToClaim = await window.api.getExternalTaskCredits(
-            reward_i.id.toString()
-          )
-          numToClaim = getDecimalNumberFromAmount(
-            taskAmountToClaim,
-            0
-          ).toString()
+          try {
+            const taskAmountToClaim = await window.api.getExternalTaskCredits(
+              reward_i.id.toString()
+            )
+            numToClaim = getDecimalNumberFromAmount(
+              taskAmountToClaim,
+              0
+            ).toString()
+          } catch (e) {
+            window.api.logError(
+              `Error getting external task credits for reward id ${reward_i}: ${e}`
+            )
+          }
         }
 
         if (


### PR DESCRIPTION
<--- Put the description here --->

currently, if the request to the external api fails, visually the quest goes into a broken state 
![image](https://github.com/user-attachments/assets/9814d509-d439-4330-a71d-ef314c784fd1)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
