### PR TITLE
fix: Preserve library status sort (#892)

### DIFF
--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -93,7 +93,7 @@ export default observer(function Library(): JSX.Element {
   // Track the screen view once and only once.
   useEffect(() => {
     window.api.trackScreen('Library')
-    libraryState.selectedFilter = filters[0]
+    libraryState.selectedFilter ??= filters[0]
   }, [])
 
   const backToTop = () => {


### PR DESCRIPTION
This fixes #892 where the library sort status is not being preserved when navigating to other pages.

