### PR TITLE
[FIX] Get Install Info failing because of WebGL platform

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,6 @@
     "editor.formatOnSave": false
   },
   "[typescriptreact]": {
-    "editor.defaultFormatter": "rvest.vs-code-prettier-eslint"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }

--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -11,11 +11,6 @@
             "message": "This Windows game will run using a compatibility layer. You might encounter some issues or the game might not work at all."
         },
         "dont-show-again": "Don't show again",
-        "error": {
-            "install": {
-                "info": ""
-            }
-        },
         "importpath": "Choose Game Folder to import",
         "move": {
             "message": "This can take a long time, are you sure?",
@@ -149,6 +144,11 @@
     },
     "launch": {
         "options": "Launch Options..."
+    },
+    "method": {
+        "getInstallInfo": {
+            "error": "Please contact the HyperPlay Team with this message: {{error}} - {{context}}."
+        }
     },
     "not_logged_in": {
         "epic": "You are not logged in with an Epic account in HyperPlay. Don't use the store page to login, click the following button instead:",

--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -11,6 +11,11 @@
             "message": "This Windows game will run using a compatibility layer. You might encounter some issues or the game might not work at all."
         },
         "dont-show-again": "Don't show again",
+        "error": {
+            "install": {
+                "info": ""
+            }
+        },
         "importpath": "Choose Game Folder to import",
         "move": {
             "message": "This can take a long time, are you sure?",

--- a/src/backend/storeManagers/hyperplay/utils.ts
+++ b/src/backend/storeManagers/hyperplay/utils.ts
@@ -12,7 +12,10 @@ import {
   qaToken,
   valistListingsApiUrl
 } from 'backend/constants'
-import { ProjectMetaInterface } from '@valist/sdk/dist/typesShared'
+import {
+  PlatformsMetaInterface,
+  ProjectMetaInterface
+} from '@valist/sdk/dist/typesShared'
 import { logError } from 'backend/api/misc'
 
 export async function getHyperPlayStoreRelease(
@@ -83,7 +86,8 @@ export function handleArchAndPlatform(
     'windows_amd64',
     'linux_amd64',
     'darwin_amd64',
-    'web'
+    'web',
+    'webgl'
   ]
   const isHpPlatform = hpPlatforms.includes(platformToInstall)
 
@@ -237,6 +241,14 @@ export function refreshGameInfoFromHpRelease(
   }
 }
 
+const getBrowserUrl = (platforms: PlatformsMetaInterface) => {
+  const webPlatform = platforms['web'] || platforms['webgl']
+  if (webPlatform && webPlatform.external_url) {
+    return webPlatform.external_url
+  }
+  return undefined
+}
+
 /**
  * This is called when adding game to library and not during refresh
  */
@@ -246,9 +258,10 @@ export function getGameInfoFromHpRelease(data: HyperPlayRelease): GameInfo {
   const platforms = data.channels[0].release_meta.platforms
   const platformKeys = Object.keys(platforms)
   if (
-    data.channels.length === 1 &&
-    platformKeys.length === 1 &&
-    platformKeys[0] === 'web'
+    (data.channels.length === 1 &&
+      platformKeys.length === 1 &&
+      platformKeys[0] === 'web') ||
+    platformKeys[0] === 'webgl'
   )
     isOnlyWeb = true
   // these are either values that should be set on initial add and not on every refreshed
@@ -275,7 +288,7 @@ export function getGameInfoFromHpRelease(data: HyperPlayRelease): GameInfo {
       title: data.project_meta.name
         ? data.project_meta.name
         : data.project_name,
-      browserUrl: isOnlyWeb ? platforms['web']?.external_url : undefined
+      browserUrl: isOnlyWeb ? getBrowserUrl(platforms) : undefined
     },
     data
   )

--- a/src/backend/storeManagers/hyperplay/utils.ts
+++ b/src/backend/storeManagers/hyperplay/utils.ts
@@ -242,7 +242,7 @@ export function refreshGameInfoFromHpRelease(
 }
 
 const getBrowserUrl = (platforms: PlatformsMetaInterface) => {
-  const webPlatform = platforms['web'] || platforms['webgl']
+  const webPlatform = platforms['web']
   if (webPlatform && webPlatform.external_url) {
     return webPlatform.external_url
   }
@@ -258,10 +258,9 @@ export function getGameInfoFromHpRelease(data: HyperPlayRelease): GameInfo {
   const platforms = data.channels[0].release_meta.platforms
   const platformKeys = Object.keys(platforms)
   if (
-    (data.channels.length === 1 &&
-      platformKeys.length === 1 &&
-      platformKeys[0] === 'web') ||
-    platformKeys[0] === 'webgl'
+    data.channels.length === 1 &&
+    platformKeys.length === 1 &&
+    platformKeys[0] === 'web'
   )
     isOnlyWeb = true
   // these are either values that should be set on initial add and not on every refreshed

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -232,15 +232,11 @@ export default observer(function GamePage(): JSX.Element | null {
               setGameInstallInfo(info)
             })
             .catch((error) => {
-              const errorMessage = t(
-                'box.error.install.info',
-                `Please contact the HyperPlay Team with this message: 
-                Error: ${error} - 
-                {{context}}.`,
-                {
-                  context: `ProjectID: ${appName} | Runner: ${runner} | Install Platform: ${installPlatform} | Channel: ${channelName} | Screen: Game Page | Method: getInstallInfo`
-                }
-              )
+              const errorMessage = t('method.getInstallInfo.error', {
+                defaultValue: `Please contact the HyperPlay Team with this message: {{error}} - {{context}}.`,
+                error: error,
+                context: `ProjectID: ${appName} | Runner: ${runner} | Install Platform: ${installPlatform} | Channel: ${channelName} | Screen: Game Page | Method: getInstallInfo`
+              })
               console.error(errorMessage)
               window.api.logError(errorMessage)
               setHasError({ error: true, message: errorMessage })

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -232,9 +232,18 @@ export default observer(function GamePage(): JSX.Element | null {
               setGameInstallInfo(info)
             })
             .catch((error) => {
-              console.error(error)
-              window.api.logError(`${`${error}`}`)
-              setHasError({ error: true, message: `${error}` })
+              const errorMessage = t(
+                'box.error.install.info',
+                `Please contact the HyperPlay Team with this message: 
+                Error: ${error} - 
+                {{context}}.`,
+                {
+                  context: `ProjectID: ${appName} | Runner: ${runner} | Install Platform: ${installPlatform} | Channel: ${channelName} | Screen: Game Page | Method: getInstallInfo`
+                }
+              )
+              console.error(errorMessage)
+              window.api.logError(errorMessage)
+              setHasError({ error: true, message: errorMessage })
             })
         }
 

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -165,7 +165,9 @@ const GameCard = ({
 
   const isHiddenGame = libraryState.isGameHidden(appName)
   const isBrowserGame =
-    installPlatform === 'Browser' || installPlatform === 'web' || installPlatform === 'webgl'
+    installPlatform === 'Browser' ||
+    installPlatform === 'web' ||
+    installPlatform === 'webgl'
 
   const onUninstallClick = function () {
     setShowUninstallModal(true)

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -165,10 +165,7 @@ const GameCard = ({
 
   const isHiddenGame = libraryState.isGameHidden(appName)
   const isBrowserGame =
-    installPlatform === 'Browser' ||
-    installPlatform === 'web' ||
-    // @ts-expect-error will need to update valist SDK first
-    installPlatform === 'webgl'
+    installPlatform === 'Browser' || installPlatform === 'web'
 
   const onUninstallClick = function () {
     setShowUninstallModal(true)

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -165,7 +165,7 @@ const GameCard = ({
 
   const isHiddenGame = libraryState.isGameHidden(appName)
   const isBrowserGame =
-    installPlatform === 'Browser' || installPlatform === 'web'
+    installPlatform === 'Browser' || installPlatform === 'web' || installPlatform === 'webgl'
 
   const onUninstallClick = function () {
     setShowUninstallModal(true)

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -167,6 +167,7 @@ const GameCard = ({
   const isBrowserGame =
     installPlatform === 'Browser' ||
     installPlatform === 'web' ||
+    // @ts-expect-error will need to update valist SDK first
     installPlatform === 'webgl'
 
   const onUninstallClick = function () {

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -413,9 +413,7 @@ export default function DownloadDialog({
   }
 
   const isWebGame =
-    gameInstallInfo?.game['name'] === 'web' ||
-    gameInstallInfo?.game['name'] === 'webgl' ||
-    platformToInstall === 'Browser'
+    gameInstallInfo?.game['name'] === 'web' || platformToInstall === 'Browser'
 
   const nativeGameIsReadyToInstall =
     installPath && gameDownloadSize && !gettingInstallInfo

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -412,7 +412,8 @@ export default function DownloadDialog({
     return t('button.no-path-selected', 'No path selected')
   }
 
-  const isWebGame = gameInstallInfo?.game['name'] === 'web'
+  const isWebGame = gameInstallInfo?.game['name'] === 'web' || gameInstallInfo?.game['name'] === 'webgl' || platformToInstall === 'Browser'
+
   const nativeGameIsReadyToInstall =
     installPath && gameDownloadSize && !gettingInstallInfo
 

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -412,7 +412,10 @@ export default function DownloadDialog({
     return t('button.no-path-selected', 'No path selected')
   }
 
-  const isWebGame = gameInstallInfo?.game['name'] === 'web' || gameInstallInfo?.game['name'] === 'webgl' || platformToInstall === 'Browser'
+  const isWebGame =
+    gameInstallInfo?.game['name'] === 'web' ||
+    gameInstallInfo?.game['name'] === 'webgl' ||
+    platformToInstall === 'Browser'
 
   const nativeGameIsReadyToInstall =
     installPath && gameDownloadSize && !gettingInstallInfo


### PR DESCRIPTION
Fix issue that is making games like The Unfettered: Awakening not loading info on the Game Page because it received `webgl` as game platform but the client doesn't understand it.
Other games that have a `WebGL` platform on the dev portal might be affect as well.

### How to Test

So Far, only game affected is The Unfettered: Awakening.

Simply add the game to your library and try to go to the game page.
On `main` it will show an error screen:
![image](https://github.com/user-attachments/assets/c2c9c677-657b-4c63-92df-e48278f9b674)

On This branch it should load the page just fine:
![image](https://github.com/user-attachments/assets/bd5edce5-7367-41e0-a3a5-a1e650e22a7d)

Installation should work just fine as well.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
