### PR TITLE
[FIX] Don't update games with removed platform build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperplay",
-  "version": "0.18.2",
+  "version": "0.19.0",
   "private": true,
   "main": "build/main/main.js",
   "homepage": "./",

--- a/src/backend/storeManagers/hyperplay/library.ts
+++ b/src/backend/storeManagers/hyperplay/library.ts
@@ -214,7 +214,7 @@ export async function listUpdateableGames(): Promise<string[]> {
       return
     }
 
-    if (!gameIsInstalled(val)) return
+    if (!gameIsInstalled(val) || val.install?.version === undefined) return
 
     if (val.channels && val.install.channelName && val.install.platform) {
       if (!Object.hasOwn(val.channels, val.install.channelName)) {
@@ -231,7 +231,7 @@ export async function listUpdateableGames(): Promise<string[]> {
       if (
         sanitizeVersion(
           val.channels[val.install.channelName].release_meta.name
-        ) !== sanitizeVersion(val.install.version!) &&
+        ) !== sanitizeVersion(val.install.version) &&
         Object.keys(
           val.channels[val.install.channelName].release_meta.platforms
         ).includes(val.install.platform)

--- a/src/backend/storeManagers/hyperplay/library.ts
+++ b/src/backend/storeManagers/hyperplay/library.ts
@@ -231,7 +231,7 @@ export async function listUpdateableGames(): Promise<string[]> {
       if (
         sanitizeVersion(
           val.channels[val.install.channelName].release_meta.name
-        ) > sanitizeVersion(val.install.version!) &&
+        ) !== sanitizeVersion(val.install.version!) &&
         Object.keys(
           val.channels[val.install.channelName].release_meta.platforms
         ).includes(val.install.platform)

--- a/src/backend/storeManagers/hyperplay/library.ts
+++ b/src/backend/storeManagers/hyperplay/library.ts
@@ -227,13 +227,14 @@ export async function listUpdateableGames(): Promise<string[]> {
         )
         return
       }
+      // if the installed version is less than the latest version && the installed platform is the same as the latest platform
       if (
-        // games installed before 0.5.0 used gameInfo.version for install.version
-        // so for backwards compatibility we remove spaces and lower case channel release meta name here
-        val.install.version !==
         sanitizeVersion(
-          val.channels[val.install.channelName].release_meta.name || ''
-        )
+          val.channels[val.install.channelName].release_meta.name
+        ) > sanitizeVersion(val.install.version!) &&
+        Object.keys(
+          val.channels[val.install.channelName].release_meta.platforms
+        ).includes(val.install.platform)
       ) {
         updateableGames.push(val.app_name)
       }


### PR DESCRIPTION
Fix issues like we had now with The Unfettered Awakening where players got the update available notification but the original build was removed only leaving the web one.

### How to Test

QASE Test: https://app.qase.io/project/HC?suite=39&previewMode=modal&case=366


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
