### PR TITLE
[FIX] Unknown platform name on sideload launch

### DIFF
--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -1247,7 +1247,7 @@ const platformMap: Record<string, PlatformName> = {
 }
 
 export function getPlatformName(platform: string): PlatformName {
-  return platformMap[platform] || 'Unknown'
+  return platformMap[platform] || platform || 'Unknown'
 }
 
 export function getExecutableAndArgs(executableWithArgs: string): {


### PR DESCRIPTION
Fix `getPlatformName` platform tracking for sideloaded games.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
