### PR TITLE
fix(overlay): show notification window on transaction request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperplay",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "private": true,
   "main": "build/main/main.js",
   "homepage": "./",

--- a/src/frontend/ExtensionManager/components/ExtensionContents/index.tsx
+++ b/src/frontend/ExtensionManager/components/ExtensionContents/index.tsx
@@ -5,8 +5,6 @@ import ExtensionContentsStyles from './index.module.scss'
 
 const trueAsStr = 'false' as unknown as boolean | undefined
 
-type ExtensionState = 'popup' | 'notification'
-
 //Module type augmentation necessary to use experimental feature nodeintegrationinsubframes
 //https://www.electronjs.org/docs/latest/api/webview-tag
 /* eslint-disable react/no-unknown-property */
@@ -26,7 +24,8 @@ const animation = {
   transition: { duration: 0.2 }
 }
 
-export function ExtensionPopup({ state }: { state: ExtensionState }) {
+export const ExtensionContents = observer(() => {
+  const state = extensionState.isPopupOpen ? 'popup' : 'notification'
   return (
     <webview
       nodeintegrationinsubframes="true"
@@ -36,30 +35,19 @@ export function ExtensionPopup({ state }: { state: ExtensionState }) {
       allowpopups={trueAsStr}
     ></webview>
   )
-}
-
-export const ExtensionContents = observer(() => {
-  const state = extensionState.isPopupOpen ? 'popup' : 'notification'
-  return <ExtensionPopup state={state} />
 })
 
 export const FloatingExtensionContents = observer(() => {
+  const shouldShow =
+    extensionState.isPopupOpen || extensionState.isNotificationOpen
   return (
     <AnimatePresence>
-      {extensionState.isPopupOpen ? (
+      {shouldShow ? (
         <motion.div
           {...animation}
           className={ExtensionContentsStyles.mmWindowContainer}
         >
-          <ExtensionPopup state="popup" />
-        </motion.div>
-      ) : null}
-      {extensionState.isNotificationOpen ? (
-        <motion.div
-          {...animation}
-          className={ExtensionContentsStyles.mmWindowContainer}
-        >
-          <ExtensionPopup state="notification" />
+          <ExtensionContents />
         </motion.div>
       ) : null}
     </AnimatePresence>

--- a/src/frontend/ExtensionManager/components/ExtensionContents/index.tsx
+++ b/src/frontend/ExtensionManager/components/ExtensionContents/index.tsx
@@ -1,3 +1,4 @@
+import { observer } from 'mobx-react-lite'
 import { motion, AnimatePresence } from 'framer-motion'
 import extensionState from 'frontend/state/ExtensionState'
 import ExtensionContentsStyles from './index.module.scss'
@@ -37,12 +38,12 @@ export function ExtensionPopup({ state }: { state: ExtensionState }) {
   )
 }
 
-export function ExtensionContents() {
+export const ExtensionContents = observer(() => {
   const state = extensionState.isPopupOpen ? 'popup' : 'notification'
   return <ExtensionPopup state={state} />
-}
+})
 
-export function FloatingExtensionContents() {
+export const FloatingExtensionContents = observer(() => {
   return (
     <AnimatePresence>
       {extensionState.isPopupOpen ? (
@@ -63,4 +64,4 @@ export function FloatingExtensionContents() {
       ) : null}
     </AnimatePresence>
   )
-}
+})

--- a/src/frontend/ExtensionManager/components/ExtensionContents/index.tsx
+++ b/src/frontend/ExtensionManager/components/ExtensionContents/index.tsx
@@ -1,9 +1,10 @@
-import React from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import extensionState from 'frontend/state/ExtensionState'
 import ExtensionContentsStyles from './index.module.scss'
 
 const trueAsStr = 'false' as unknown as boolean | undefined
+
+type ExtensionState = 'popup' | 'notification'
 
 //Module type augmentation necessary to use experimental feature nodeintegrationinsubframes
 //https://www.electronjs.org/docs/latest/api/webview-tag
@@ -24,31 +25,24 @@ const animation = {
   transition: { duration: 0.2 }
 }
 
-export function ExtensionPopup() {
+export function ExtensionPopup({ state }: { state: ExtensionState }) {
   return (
     <webview
       nodeintegrationinsubframes="true"
       webpreferences="contextIsolation=true, nodeIntegration=true"
-      src={`chrome-extension://${extensionState.extensionId}/popup.html`}
+      src={`chrome-extension://${extensionState.extensionId}/${state}.html`}
       className={ExtensionContentsStyles.mmWindow}
       allowpopups={trueAsStr}
     ></webview>
   )
 }
 
-export function ExtensionNotification() {
-  return (
-    <webview
-      nodeintegrationinsubframes="true"
-      webpreferences="contextIsolation=true, nodeIntegration=true"
-      src={`chrome-extension://${extensionState.extensionId}/notification.html`}
-      className={ExtensionContentsStyles.mmWindow}
-      allowpopups={trueAsStr}
-    ></webview>
-  )
+export function ExtensionContents() {
+  const state = extensionState.isPopupOpen ? 'popup' : 'notification'
+  return <ExtensionPopup state={state} />
 }
 
-export default function ExtensionContents() {
+export function FloatingExtensionContents() {
   return (
     <AnimatePresence>
       {extensionState.isPopupOpen ? (
@@ -56,7 +50,7 @@ export default function ExtensionContents() {
           {...animation}
           className={ExtensionContentsStyles.mmWindowContainer}
         >
-          <ExtensionPopup />
+          <ExtensionPopup state="popup" />
         </motion.div>
       ) : null}
       {extensionState.isNotificationOpen ? (
@@ -64,7 +58,7 @@ export default function ExtensionContents() {
           {...animation}
           className={ExtensionContentsStyles.mmWindowContainer}
         >
-          <ExtensionNotification />
+          <ExtensionPopup state="notification" />
         </motion.div>
       ) : null}
     </AnimatePresence>

--- a/src/frontend/ExtensionManager/index.tsx
+++ b/src/frontend/ExtensionManager/index.tsx
@@ -4,8 +4,9 @@ import { observer } from 'mobx-react-lite'
 import extensionState from 'frontend/state/ExtensionState'
 import OverlayState from 'frontend/state/OverlayState'
 import ContextProvider from 'frontend/state/ContextProvider'
-import ExtensionContents, {
-  ExtensionPopup
+import {
+  FloatingExtensionContents,
+  ExtensionContents
 } from './components/ExtensionContents'
 
 const ExtensionManager = function () {
@@ -42,7 +43,7 @@ const ExtensionManager = function () {
   }
 
   if (isOverlay) {
-    return <ExtensionPopup />
+    return <ExtensionContents />
   }
 
   /* eslint-disable react/no-unknown-property */
@@ -52,7 +53,7 @@ const ExtensionManager = function () {
       ref={rootRef}
       style={mmContainerStyle}
     >
-      <ExtensionContents />
+      <FloatingExtensionContents />
     </dialog>
   )
 }

--- a/src/frontend/OverlayManager/Overlay/index.module.scss
+++ b/src/frontend/OverlayManager/Overlay/index.module.scss
@@ -1,5 +1,3 @@
-$topNavBarHeight: 30px;
-
 .root {
   position: absolute;
   z-index: 4;
@@ -16,22 +14,10 @@ $topNavBarHeight: 30px;
   opacity: 90%;
 }
 
-.closeOverlayText {
-  position: absolute;
-  top: calc($topNavBarHeight + 10px);
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 3;
-}
-
 .overlayToggleHint {
-  padding: 10px;
-  display: inline-block;
-  white-space: pre-line;
-  max-width: 360px;
-  z-index: 3;
-  top: calc($topNavBarHeight + 10px);
-  position: absolute;
+  display: flex;
+  max-width: 280px;
+  text-align: end;
 }
 
 .bgFilter {


### PR DESCRIPTION
<--- Put the description here --->

With the update to the overlay layout, there was a regression in the MM window, and now, when the overlay is open and there is a transaction request, we don't show the notification popup automatically, closing and re-opening the overlay is needed.

You can test this in dev mode in `main` by connecting your wallet and requesting a signature from the console:

```
await window.ethereum.request({
        method: 'personal_sign',
        params: ['Hi', (await window.ethereum.request({ method: 'eth_requestAccounts' }))[0]]
      });
 ```

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
