### PR TITLE
[Fix] Fix overlay not showing for some epic fwd listings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperplay",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "private": true,
   "main": "build/main/main.js",
   "homepage": "./",

--- a/src/backend/storeManagers/hyperplay/utils.ts
+++ b/src/backend/storeManagers/hyperplay/utils.ts
@@ -50,9 +50,11 @@ export async function getHyperPlayNameToReleaseMap() {
 
   const hpStoreGameMap = new Map<string, HyperPlayRelease>()
 
-  hpStoreGameReleases.forEach((val) => {
-    hpStoreGameMap.set(val.project_name.toLowerCase(), val)
-  })
+  hpStoreGameReleases
+    .filter((val) => !!val.project_meta.name)
+    .forEach((val) => {
+      hpStoreGameMap.set(val.project_meta.name!.toLowerCase(), val)
+    })
 
   return hpStoreGameMap
 }


### PR DESCRIPTION
# Summary

Fix overlay not showing for some epic forwarder listings. Use `project_meta.name` to match on title from now on.