### PR TITLE
[Fix] Sync playsession for non-hp runners

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperplay",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "private": true,
   "main": "build/main/main.js",
   "homepage": "./",
@@ -169,7 +169,6 @@
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@hyperplay/chains": "^0.3.0",
     "@hyperplay/check-disk-space": "^3.5.2",
-    "@hyperplay/quests-ui": "^0.0.21",
     "@hyperplay/ui": "^1.7.18",
     "@hyperplay/utils": "^0.2.4",
     "@mantine/carousel": "^7.12.0",

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@hyperplay/chains": "^0.3.0",
     "@hyperplay/check-disk-space": "^3.5.2",
+    "@hyperplay/quests-ui": "^0.0.25",
     "@hyperplay/ui": "^1.7.18",
     "@hyperplay/utils": "^0.2.4",
     "@mantine/carousel": "^7.12.0",

--- a/src/frontend/OverlayManager/Overlay/index.module.scss
+++ b/src/frontend/OverlayManager/Overlay/index.module.scss
@@ -52,3 +52,7 @@
   flex-direction: column;
   gap: var(--space-2lg);
 }
+
+.hideOverlay {
+  display: none;
+}

--- a/src/frontend/OverlayManager/Overlay/index.tsx
+++ b/src/frontend/OverlayManager/Overlay/index.tsx
@@ -13,6 +13,7 @@ import { Button } from '@hyperplay/ui'
 import { QuestsViewer } from 'frontend/components/UI/QuestsViewer'
 import { useFlags } from 'launchdarkly-react-client-sdk'
 import libraryState from 'frontend/state/libraryState'
+import classNames from 'classnames'
 
 export const Overlay = observer(function ({
   appName,
@@ -118,8 +119,10 @@ export const Overlay = observer(function ({
       questsViewer = <QuestsViewer projectId={appName} />
     }
 
+    const classNameMods: Record<string, boolean> = {}
+    classNameMods[BrowserGameStyles.hideOverlay] = !OverlayState.showOverlay
     overlayItems = (
-      <div className={BrowserGameStyles.root}>
+      <div className={classNames(BrowserGameStyles.root, classNameMods)}>
         <div className={BrowserGameStyles.bgFilter} />
         <div className={BrowserGameStyles.contentContainer}>
           {questsViewer}

--- a/src/frontend/OverlayManager/index.tsx
+++ b/src/frontend/OverlayManager/index.tsx
@@ -43,9 +43,7 @@ const OverlayManager = observer(function ({
         style={style}
         id="overlay-manager"
       >
-        {OverlayState.showOverlay ? (
-          <Overlay appName={appName} runner={runner} />
-        ) : null}
+        <Overlay appName={appName} runner={runner} />
         {url !== 'ignore' && OverlayState.renderState.showBrowserGame ? (
           <div>
             <WebviewControls

--- a/src/frontend/components/UI/QuestsViewer/index.tsx
+++ b/src/frontend/components/UI/QuestsViewer/index.tsx
@@ -69,6 +69,10 @@ export function QuestsViewer({ projectId: appName }: QuestsViewerProps) {
           setSelectedQuestId={setSelectedQuestId}
         />
         <QuestDetailsWrapper
+          questsWithExternalPlayStreakSync={[]}
+          syncPlayStreakWithExternalSource={async () =>
+            console.log('sync external')
+          }
           tOverride={t}
           sessionEmail={sessionEmail}
           className={styles.detailsWrapper}

--- a/src/frontend/components/UI/QuestsViewer/index.tsx
+++ b/src/frontend/components/UI/QuestsViewer/index.tsx
@@ -73,7 +73,6 @@ export function QuestsViewer({ projectId: appName }: QuestsViewerProps) {
           syncPlayStreakWithExternalSource={async () =>
             console.log('sync external')
           }
-          // @ts-expect-error TFunction type mismatch
           tOverride={t}
           sessionEmail={sessionEmail}
           className={styles.detailsWrapper}

--- a/src/frontend/components/UI/QuestsViewer/index.tsx
+++ b/src/frontend/components/UI/QuestsViewer/index.tsx
@@ -73,6 +73,7 @@ export function QuestsViewer({ projectId: appName }: QuestsViewerProps) {
           syncPlayStreakWithExternalSource={async () =>
             console.log('sync external')
           }
+          // @ts-expect-error TFunction type mismatch
           tOverride={t}
           sessionEmail={sessionEmail}
           className={styles.detailsWrapper}

--- a/src/frontend/helpers/getPlaystreakArgsFromQuestData.ts
+++ b/src/frontend/helpers/getPlaystreakArgsFromQuestData.ts
@@ -24,7 +24,8 @@ export function getPlaystreakArgsFromQuestData(
       new Date().toISOString(),
     accumulatedPlaytimeTodayInSeconds:
       questPlayStreakData?.accumulated_playtime_today_in_seconds ?? 0,
-    dateTimeCurrentSessionStartedInMsSinceEpoch: sessionStartedTime
+    dateTimeCurrentSessionStartedInMsSinceEpoch: sessionStartedTime,
+    onSync: () => console.log('onSync called')
   }
 }
 

--- a/src/frontend/screens/Quests/components/QuestDetailsViewPlay/index.tsx
+++ b/src/frontend/screens/Quests/components/QuestDetailsViewPlay/index.tsx
@@ -142,6 +142,7 @@ export function QuestDetailsViewPlayWrapper({
     },
     sync: t('quest.sync', 'Sync'),
     streakProgressI18n: {
+      sync: 'Sync',
       streakProgress: t('quest.playstreak.streakProgress', 'Streak Progress'),
       days: t('quest.playstreak.days', 'days'),
       playToStart: t(
@@ -191,7 +192,8 @@ export function QuestDetailsViewPlayWrapper({
             requiredStreakInDays: 1,
             minimumSessionTimeInSeconds: 100,
             accumulatedPlaytimeTodayInSeconds: 0,
-            lastPlaySessionCompletedDateTimeUTC: new Date().toISOString()
+            lastPlaySessionCompletedDateTimeUTC: new Date().toISOString(),
+            onSync: () => console.log('onSync called')
           }
         }}
         classNames={{ root: styles.questDetailsRoot }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,7 +1151,7 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.6.0.tgz#31ab07ca6a06358c5de4d295d4711b675006163f"
   integrity sha512-xyX0X9mc0kyz9plIyryrRbl7ngsA9jz77mCZJsUkLl+ZKs0KWObgaEBoSgQiYWAsSmjz/yjl0F++Got0Mdp4Rw==
 
-"@fortawesome/fontawesome-svg-core@^6.1.1":
+"@fortawesome/fontawesome-svg-core@^6.1.1", "@fortawesome/fontawesome-svg-core@^6.4.0":
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.6.0.tgz#2a24c32ef92136e98eae2ff334a27145188295ff"
   integrity sha512-KHwPkCk6oRT4HADE7smhfsKudt9N/9lm6EJ5BVg0tD1yPA5hht837fB87F8pn15D8JfTqQOjhKTktwmLMiD7Kg==
@@ -1165,21 +1165,21 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.6.0"
 
-"@fortawesome/free-regular-svg-icons@^6.6.0":
+"@fortawesome/free-regular-svg-icons@^6.4.0", "@fortawesome/free-regular-svg-icons@^6.6.0":
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.6.0.tgz#fc49a947ac8dfd20403c9ea5f37f0919425bdf04"
   integrity sha512-Yv9hDzL4aI73BEwSEh20clrY8q/uLxawaQ98lekBx6t9dQKDHcDzzV1p2YtBGTtolYtNqcWdniOnhzB+JPnQEQ==
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.6.0"
 
-"@fortawesome/free-solid-svg-icons@^6.6.0":
+"@fortawesome/free-solid-svg-icons@^6.4.0", "@fortawesome/free-solid-svg-icons@^6.6.0":
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.6.0.tgz#061751ca43be4c4d814f0adbda8f006164ec9f3b"
   integrity sha512-IYv/2skhEDFc2WGUcqvFJkeK39Q+HyPf5GHUrT/l2pKbtgEIv1al1TKd6qStR5OIwQdN1GZP54ci3y4mroJWjA==
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.6.0"
 
-"@fortawesome/react-fontawesome@^0.2.2":
+"@fortawesome/react-fontawesome@^0.2.0", "@fortawesome/react-fontawesome@^0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz#68b058f9132b46c8599875f6a636dad231af78d4"
   integrity sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==
@@ -1232,6 +1232,13 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz#4a2868d75d6d6963e423bcf90b7fd1be343409d3"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
+
+"@hyperplay/chains@^0.2.9":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@hyperplay/chains/-/chains-0.2.10.tgz#6c9d4e175146d79e4556039db487c182d60c533d"
+  integrity sha512-TUe9vJo9jXx23pb5QlGuW6xo6JmXYjqXKJSma//aUPZ99HU8I/lATlyqdXwozPfQ2qGsAYn58FCTo2kbF+J+8w==
+  dependencies:
+    axios "^1.4.0"
 
 "@hyperplay/chains@^0.3.0":
   version "0.3.0"
@@ -1317,9 +1324,9 @@
     classnames "^2.5.1"
 
 "@hyperplay/ui@^1.7.18":
-  version "1.7.19"
-  resolved "https://registry.yarnpkg.com/@hyperplay/ui/-/ui-1.7.19.tgz#43bc58405a5cc4866d55b548203ce2bdeca6d3fa"
-  integrity sha512-uXqjABDqxvjXbF7o+GMriXyTgp62X39aPohr4W26G2uk+r+vNNy3t0JDGd0B4SyZnovcoCEocfWS6oirAOVnNg==
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@hyperplay/ui/-/ui-1.8.2.tgz#cbc0c38f431787a778162763dc342800523abe9d"
+  integrity sha512-UxV2/g5/bG3FYk3DcU45oqDX/gCh9vXu6cZClBrVq0lje+K+JRCKQSnvSNTMbq8ubG2BOtuTiW1j1b5AAeYJrw==
 
 "@hyperplay/utils@^0.0.12":
   version "0.0.12"
@@ -1339,6 +1346,13 @@
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/@hyperplay/utils/-/utils-0.0.9.tgz#80836cfde5c4d63e41f5df809ae2e80314600c5a"
   integrity sha512-gMAa6gdFXfLrJUjPAD2is06qNo4MHzpb6Cbzt4xfNd7wI9chOblQ+piwTI1oFWs44GgfacsMq6i5esNly3hELg==
+  dependencies:
+    bignumber.js "^9.1.2"
+
+"@hyperplay/utils@^0.1.0":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@hyperplay/utils/-/utils-0.1.4.tgz#e36cfd82febaae1c54cec1e65649169ede518dae"
+  integrity sha512-brHHvhSl5fOLIX2hCp2ZP0dfdMHb8uGME3o3NjK0imVdYlspUVe1YXp5x9P5O2iJn+7C3oPlbLARsC/KTDWSJw==
   dependencies:
     bignumber.js "^9.1.2"
 
@@ -2984,6 +2998,19 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@tabler/icons-react@^2.46.0":
+  version "2.47.0"
+  resolved "https://registry.yarnpkg.com/@tabler/icons-react/-/icons-react-2.47.0.tgz#b704e7ae98f95be8bd6e938b4b2e84cd20b0cf31"
+  integrity sha512-iqly2FvCF/qUbgmvS8E40rVeYY7laltc5GUjRxQj59DuX0x/6CpKHTXt86YlI2whg4czvd/c8Ce8YR08uEku0g==
+  dependencies:
+    "@tabler/icons" "2.47.0"
+    prop-types "^15.7.2"
+
+"@tabler/icons@2.47.0":
+  version "2.47.0"
+  resolved "https://registry.yarnpkg.com/@tabler/icons/-/icons-2.47.0.tgz#c41c680d1947e3ab2d60af3febc4132287c60596"
+  integrity sha512-4w5evLh+7FUUiA1GucvGj2ReX2TvOjEr4ejXdwL/bsjoSkof6r1gQmzqI+VHrE2CpJpB3al7bCTulOkFa/RcyA==
+
 "@tanstack/query-core@5.52.2":
   version "5.52.2"
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.52.2.tgz#a023864a892fda9858b724d667eb19cd84ce054a"
@@ -3754,6 +3781,17 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
+
+"@valist/sdk@^2.9.1":
+  version "2.10.5"
+  resolved "https://registry.yarnpkg.com/@valist/sdk/-/sdk-2.10.5.tgz#e43cafc101d42097c6191ae2ac0f426b62603520"
+  integrity sha512-2m95VJfljJQXaSUfqfVwfHsaVcgynY4yy6wKjIsACYgiKkzck2XqjyAOtLhRESyzvuNvBA/ypj0mP+JxdmCtOw==
+  dependencies:
+    "@ethersproject/contracts" "^5.7.0"
+    axios "^1.4.0"
+    axios-retry "^4.4.1"
+    ethers "^6.11.1"
+    node-fetch "^2.6.1"
 
 "@valist/sdk@^2.9.17":
   version "2.9.17"
@@ -6920,6 +6958,13 @@ eth-rpc-errors@^4.0.2, eth-rpc-errors@^4.0.3:
   integrity sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==
   dependencies:
     fast-safe-stringify "^2.0.6"
+
+ethereum-blockies-base64@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ethereum-blockies-base64/-/ethereum-blockies-base64-1.0.2.tgz#4aebca52142bf4d16a3144e6e2b59303e39ed2b3"
+  integrity sha512-Vg2HTm7slcWNKaRhCUl/L3b4KrB8ohQXdd5Pu3OI897EcR6tVRvUqdTwAyx+dnmoDzj8e2bwBLDQ50ByFmcz6w==
+  dependencies:
+    pnglib "0.0.1"
 
 ethereum-cryptography@^2.0.0:
   version "2.2.1"
@@ -11122,6 +11167,11 @@ pngjs@^5.0.0:
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-5.0.0.tgz#e79dd2b215767fd9c04561c01236df960bce7fbb"
   integrity sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==
 
+pnglib@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/pnglib/-/pnglib-0.0.1.tgz#f9ab6f9c688f4a9d579ad8be28878a716e30c096"
+  integrity sha512-95ChzOoYLOPIyVmL+Y6X+abKGXUJlvOVLkB1QQkyXl7Uczc6FElUy/x01NS7r2GX6GRezloO/ecCX9h4U9KadA==
+
 pony-cause@^2.1.10:
   version "2.1.11"
   resolved "https://registry.yarnpkg.com/pony-cause/-/pony-cause-2.1.11.tgz#d69a20aaccdb3bdb8f74dd59e5c68d8e6772e4bd"
@@ -11271,7 +11321,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.8.1:
+prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1309,13 +1309,6 @@
     supertest "^6.3.3"
     zod "^3.22.4"
 
-"@hyperplay/quests-ui@^0.0.21":
-  version "0.0.21"
-  resolved "https://registry.yarnpkg.com/@hyperplay/quests-ui/-/quests-ui-0.0.21.tgz#b14f70bac0eece560b5950f1b61c5d7e04fb6594"
-  integrity sha512-pqQN5s3UlLHQ02Bb63D8ftQFlZWPaKoXoP32Y++fgjsdKMw0pTGX3S1PxIkzXY+efbQcX5SDOVRrLX9qq0bj0Q==
-  dependencies:
-    classnames "^2.5.1"
-
 "@hyperplay/ui@^1.7.18":
   version "1.7.19"
   resolved "https://registry.yarnpkg.com/@hyperplay/ui/-/ui-1.7.19.tgz#43bc58405a5cc4866d55b548203ce2bdeca6d3fa"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1309,6 +1309,13 @@
     supertest "^6.3.3"
     zod "^3.22.4"
 
+"@hyperplay/quests-ui@^0.0.25":
+  version "0.0.25"
+  resolved "https://registry.yarnpkg.com/@hyperplay/quests-ui/-/quests-ui-0.0.25.tgz#6506c0616fcb53fc181f4ed3b32badae81fbc3cf"
+  integrity sha512-PJH8dGEbFpTzVIeQMGyW6aFl3SKeTPbR7E7sPYUwkZS/aQaz7bxAQu0vfyUFuHla5VMFWEtpRaQaghygnFPXVg==
+  dependencies:
+    classnames "^2.5.1"
+
 "@hyperplay/ui@^1.7.18":
   version "1.7.19"
   resolved "https://registry.yarnpkg.com/@hyperplay/ui/-/ui-1.7.19.tgz#43bc58405a5cc4866d55b548203ce2bdeca6d3fa"


### PR DESCRIPTION
# Summary

Pulls in https://github.com/HyperPlay-Gaming/quests-ui/pull/18

Previously the `Overlay` was conditionally rendered on overlay toggle, causing re-renders that reset the sync timer. Now the overlay is hidden but not removed from the DOM so that the sync hooks won't reset on overlay toggle.

# Testing 
https://app.qase.io/project/HC?suite=75&previewMode=modal&case=368