### PR TITLE
[Tech] Fix linux build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           path: dist/HyperPlay*.exe
           retention-days: 7
   build_linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     concurrency:
       group: build-linux-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,13 +46,11 @@ jobs:
           path: dist/HyperPlay*.exe
           retention-days: 7
   build_linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     concurrency:
       group: build-linux-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - name: Install libarchive-tools for pacman build # Related https://github.com/electron-userland/electron-builder/issues/4181
-        run: sudo apt-get install libarchive-tools
       - name: Checkout repository.
         uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,10 @@ jobs:
       group: build-linux-${{ github.ref }}
       cancel-in-progress: true
     steps:
+      - name: Update deps
+        run: sudo apt-get update
+      - name: Install libarchive-tools for pacman build # Related https://github.com/electron-userland/electron-builder/issues/4181
+        run: sudo apt-get install libarchive-tools
       - name: Checkout repository.
         uses: actions/checkout@v4
 

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -12,8 +12,10 @@ env:
 
 jobs:
   draft-releases:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
+      - name: Update deps
+        run: sudo apt-get update
       - run: sudo apt-get install --no-install-recommends -y libarchive-tools libopenjp2-tools rpm
       - name: Checkout repository.
         uses: actions/checkout@v4

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   draft-releases:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - run: sudo apt-get install --no-install-recommends -y libarchive-tools libopenjp2-tools rpm
       - name: Checkout repository.


### PR DESCRIPTION
# Summary

With the update to jammy, we needed to run `sudo apt-get update` first before installing `libarchive-tools`