### PR TITLE
[UI] show gradient border on quest card selected

### DIFF
--- a/src/frontend/screens/Quests/components/QuestsSummaryTableWrapper/index.tsx
+++ b/src/frontend/screens/Quests/components/QuestsSummaryTableWrapper/index.tsx
@@ -108,6 +108,7 @@ export function QuestsSummaryTableWrapper({
           }}
           selected={id === selectedQuestId}
           description={name}
+          className={id === selectedQuestId ? 'gradientBorder' : undefined}
         />
       )
     }) ?? []


### PR DESCRIPTION
# Summary

closes https://github.com/HyperPlay-Gaming/product-management/issues/517

# Testing

1. Go to the quests page 
2. Click on a card
3. Observe that the gradient border remains on that card even when not hovering it