### PR TITLE
[TECH] Disable Auto-Update for Linux binaries (for now)

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -15,7 +15,6 @@ import {
   gamesConfigPath,
   installPath,
   userHome,
-  isFlatpak,
   isMac,
   isWindows,
   getSteamCompatFolder,

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -296,7 +296,7 @@ class GlobalConfigV0 extends GlobalConfig {
       autoInstallDxvkNvapi: false,
       addSteamShortcuts: false,
       preferSystemLibs: false,
-      checkForUpdatesOnStartup: !isFlatpak,
+      checkForUpdatesOnStartup: !isLinux,
       autoUpdateGames: true,
       customWinePaths: isWindows ? null : [],
       defaultInstallPath: installPath,

--- a/src/backend/updater.ts
+++ b/src/backend/updater.ts
@@ -2,7 +2,7 @@ import { dialog, shell } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import { t } from 'i18next'
 
-import { configStore, icon } from './constants'
+import { configStore, icon, isLinux } from './constants'
 import { logError, logInfo, LogPrefix } from './logger/logger'
 import { isOnline } from './online_monitor'
 import { trackEvent } from './api/metrics'
@@ -16,7 +16,7 @@ const appSettings = configStore.get_nodefault('settings')
 const shouldCheckForUpdates = appSettings?.checkForUpdatesOnStartup === true
 let newVersion: string
 
-autoUpdater.autoDownload = shouldCheckForUpdates
+autoUpdater.autoDownload = shouldCheckForUpdates && !isLinux
 autoUpdater.autoInstallOnAppQuit = true
 
 let isAppUpdating = false


### PR DESCRIPTION
Since we update to the latest version of electron-updater it enabled auto-update for DEB. RPM and PACMAN. The problem is that it is not stable on all distros and also we already publish the pacman file on AUR so it conflicts with the ARCH updates.
There are also some cases where it needs elevation but the distro won't ask for it.
So we should disable it for now until we test this feature a bit more.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
