### PR TITLE
[Fix] UI - overflow of quests container when logged out in overlay

### DIFF
--- a/src/frontend/components/UI/QuestsViewer/index.module.scss
+++ b/src/frontend/components/UI/QuestsViewer/index.module.scss
@@ -9,8 +9,9 @@
   display: flex;
   flex-direction: row;
   align-items: stretch;
-  flex: 1;
+  flex-shrink: 1;
   max-height: 100%;
+  overflow: hidden;
 }
 
 .detailsWrapper {

--- a/src/frontend/components/UI/QuestsViewer/index.module.scss
+++ b/src/frontend/components/UI/QuestsViewer/index.module.scss
@@ -9,9 +9,9 @@
   display: flex;
   flex-direction: row;
   align-items: stretch;
-  flex-shrink: 1;
+  flex: 1;
   max-height: 100%;
-  overflow: hidden;
+  min-height: 0px;
 }
 
 .detailsWrapper {


### PR DESCRIPTION
# Summary

When logged out of HP, the quests viewer div was overflowing the page and the whole overlay was scrollable.

This keeps the container within the viewport and keeps the scrolling only inside the content of the quests viewer.