### PR TITLE
[Fix] Network add in portfolio swap

### DIFF
--- a/src/backend/proxy/providerPreload.ts
+++ b/src/backend/proxy/providerPreload.ts
@@ -37,8 +37,33 @@ const listenToRendererCalls = (fxn: string, topic: string, cb: any) => {
   })
 }
 
+function extractJSONAfterError(input: string): object | null {
+  try {
+      // Match the pattern where "error=" precedes a JSON string
+      const errorPattern = /error=(\{[^{}]*\})/;
+
+      const match = input.match(errorPattern);
+
+      if (match && match[1]) {
+          // Parse the JSON string captured by the regex
+          return JSON.parse(match[1]);
+      }
+
+      // Return null if no valid JSON is found
+      return null;
+  } catch (error) {
+      console.error("Error parsing JSON:", error);
+      return null;
+  }
+}
+
 const provRequest = async (args: RequestArguments) => {
   const x = await ipcRenderer.invoke('providerRequest', args)
+  const jsonErrorInString = extractJSONAfterError(`${x}`)
+  if (jsonErrorInString !== null){
+    throw jsonErrorInString
+  }
+  
   if (
     x !== null &&
     x !== 'undefined' &&

--- a/src/backend/proxy/providerPreload.ts
+++ b/src/backend/proxy/providerPreload.ts
@@ -39,31 +39,31 @@ const listenToRendererCalls = (fxn: string, topic: string, cb: any) => {
 
 function extractJSONAfterError(input: string): object | null {
   try {
-      // Match the pattern where "error=" precedes a JSON string
-      const errorPattern = /error=(\{[^{}]*\})/;
+    // Match the pattern where "error=" precedes a JSON string
+    const errorPattern = /error=(\{[^{}]*\})/
 
-      const match = input.match(errorPattern);
+    const match = input.match(errorPattern)
 
-      if (match && match[1]) {
-          // Parse the JSON string captured by the regex
-          return JSON.parse(match[1]);
-      }
+    if (match && match[1]) {
+      // Parse the JSON string captured by the regex
+      return JSON.parse(match[1])
+    }
 
-      // Return null if no valid JSON is found
-      return null;
+    // Return null if no valid JSON is found
+    return null
   } catch (error) {
-      console.error("Error parsing JSON:", error);
-      return null;
+    console.error('Error parsing JSON:', error)
+    return null
   }
 }
 
 const provRequest = async (args: RequestArguments) => {
   const x = await ipcRenderer.invoke('providerRequest', args)
   const jsonErrorInString = extractJSONAfterError(`${x}`)
-  if (jsonErrorInString !== null){
+  if (jsonErrorInString !== null) {
     throw jsonErrorInString
   }
-  
+
   if (
     x !== null &&
     x !== 'undefined' &&


### PR DESCRIPTION
# Summary

closes https://github.com/HyperPlay-Gaming/product-management/issues/765

Ethers has several situations where it throws an error like the following

```
Error: could not coalesce error (error={ "code": 4902, "message": "Unrecognized chain ID \"0x144\". Try adding the chain using wallet_addEthereumChain first." }, payload={ "id": 13, "jsonrpc": "2.0", "method": "wallet_switchEthereumChain", "params": [ { "chainId": "0x144" } ] }, code=UNKNOWN_ERROR, version=6.13.2)
```

e.g. https://github.com/ethers-io/ethers.js/issues/4576

The above error was generated when trying to switch chains. Because `makeError` fails at `ethers\lib.commonjs\utils\errors.js`, the error object is not correctly formed. We can parse the error object out of the error string as a fallback here.

Note that since this error was not being re-thrown, the catch block in the portfolio that checks the error code `E.code === 4902` was not returning true resulting in `wallet_addEthereumChain` not being called.

The user impact is that chains that were not already added to the users wallet could not be added/switched to in the portfolio.




