### PR TITLE
[FIX] Update Game status after finishing playing and not logged in

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperplay",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "private": true,
   "main": "build/main/main.js",
   "homepage": "./",

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1332,6 +1332,12 @@ ipcMain.handle(
     await addRecentGame(game)
 
     if (autoSyncSaves && isOnline()) {
+      /**
+       * @dev It sets to done, so the GlobalState knows that the game session stopped.
+       * Then it changes the status to syncing-saves. Then It sets to done again.
+       * Otherwise it would count the Syncing Saves time (which can be long depending on the game) as playing time as well.
+       * done is not only the state for stopping playing but for finishing any other process that came before.
+       */
       sendFrontendMessage('gameStatusUpdate', {
         appName,
         runner,

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1113,7 +1113,7 @@ function startNewPlaySession(appName: string) {
 
 async function syncPlaySession(appName: string, runner: Runner) {
   if (!Object.hasOwn(gamePlaySessionStartTimes, appName)) {
-    return
+    return BigInt(0)
   }
 
   // reset the time counter and start new session slightly before ending current session to prevent time loss
@@ -1366,16 +1366,8 @@ ipcMain.handle(
       status: 'done'
     })
 
-    // Playtime of this session in minutes. Uses hrtime for monotonic timer not subject to clock drift or sync errors
-    let sessionPlaytimeInMs: bigint | undefined = undefined
-    try {
-      sessionPlaytimeInMs = await syncPlaySession(appName, runner)
-    } catch (error) {
-      logWarning(
-        `Error syncing playtime for ${appName}. Error: ${error}`,
-        LogPrefix.Backend
-      )
-    }
+    // Playtime of this session in milliseconds. Uses hrtime for monotonic timer not subject to clock drift or sync errors
+    const sessionPlaytimeInMs = await syncPlaySession(appName, runner)
 
     trackEvent({
       event: 'Game Closed',
@@ -1386,7 +1378,7 @@ ipcMain.handle(
         store_name: getStoreName(runner),
         browserUrl: browserUrl ?? undefined,
         platform: getPlatformName(install.platform!),
-        playTimeInMs: Number(sessionPlaytimeInMs ?? 0),
+        playTimeInMs: Number(sessionPlaytimeInMs),
         platform_arch: install.platform!
       }
     })

--- a/src/backend/utils/quests.ts
+++ b/src/backend/utils/quests.ts
@@ -7,36 +7,41 @@ export async function postPlaySessionTime(
   appName: string,
   playSessionInSeconds: number
 ) {
-  logInfo(
-    `Posting play session for project id ${appName}. Time played in seconds was ${playSessionInSeconds}`,
-    LogPrefix.HyperPlay
-  )
-  const cookieString = await getPartitionCookies({
-    partition: 'persist:auth',
-    url: DEV_PORTAL_URL
-  })
-  const response = await fetch(`${DEV_PORTAL_URL}api/v1/quests/playStreak`, {
-    method: 'POST',
-    headers: {
-      Cookie: cookieString
-    },
-    body: JSON.stringify({
-      project_id: appName,
-      play_session_in_seconds: playSessionInSeconds
+  try {
+    logInfo(
+      `Posting play session for project id ${appName}. Time played in seconds was ${playSessionInSeconds}`,
+      LogPrefix.HyperPlay
+    )
+    const cookieString = await getPartitionCookies({
+      partition: 'persist:auth',
+      url: DEV_PORTAL_URL
     })
-  })
-  if (!response.ok) {
-    throw await response.text()
+    const response = await fetch(`${DEV_PORTAL_URL}api/v1/quests/playStreak`, {
+      method: 'POST',
+      headers: {
+        Cookie: cookieString
+      },
+      body: JSON.stringify({
+        project_id: appName,
+        play_session_in_seconds: playSessionInSeconds
+      })
+    })
+    if (!response.ok) {
+      throw await response.text()
+    }
+    const resultJson = await response.json()
+    logInfo(
+      `Posted playstreak playsession. response: ${JSON.stringify(
+        resultJson,
+        null,
+        4
+      )}`,
+      LogPrefix.HyperPlay
+    )
+  } catch (error) {
+    logInfo(`Error in postPlaySessionTime: ${error}`, LogPrefix.HyperPlay)
+    throw error
   }
-  const resultJson = await response.json()
-  logInfo(
-    `Posted playstreak playsession. response: ${JSON.stringify(
-      resultJson,
-      null,
-      4
-    )}`,
-    LogPrefix.HyperPlay
-  )
 }
 
 export async function checkG7ConnectionStatus() {


### PR DESCRIPTION
Fix an issue where the game status won't change after finishing playing and the player is not logged in on HyperPlay.
The issue was because it was getting stuck on the `syncPlaySession` method and was never triggering the `gameStatusUpdate` with the `done` status.

Moved this one to be above the playtime and also added some `try/catch` to the sync methods.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
