### PR TITLE
rm global class from weclome modal lang selector

### DIFF
--- a/src/frontend/components/UI/LanguageSelector/index.tsx
+++ b/src/frontend/components/UI/LanguageSelector/index.tsx
@@ -15,6 +15,7 @@ export enum FlagPosition {
 interface Props {
   flagPossition?: FlagPosition
   showWeblateLink?: boolean
+  extraClass?: string
 }
 
 const languageLabels: { [key: string]: string } = {
@@ -103,7 +104,8 @@ const languageFlags: { [key: string]: string } = {
 
 export default function LanguageSelector({
   flagPossition = FlagPosition.NONE,
-  showWeblateLink = false
+  showWeblateLink = false,
+  extraClass = 'languageSelector'
 }: Props) {
   const { t, i18n } = useTranslation()
   const { language, setLanguage } = useContext(ContextProvider)
@@ -162,7 +164,7 @@ export default function LanguageSelector({
         onChange={(event) => handleChangeLanguage(event.target.value)}
         value={currentLanguage}
         label={t('setting.language', 'Choose Language')}
-        extraClass="languageSelector"
+        extraClass={extraClass}
         afterSelect={afterSelect}
       >
         {Object.keys(languageLabels).map((lang) => renderOption(lang))}

--- a/src/frontend/screens/Onboarding/welcome/index.tsx
+++ b/src/frontend/screens/Onboarding/welcome/index.tsx
@@ -115,7 +115,7 @@ const Welcome: React.FC<WelcomeProps> = function (props) {
         </div>
       </div>
       <div className={WelcomeStyles.languageSelector}>
-        <LanguageSelector flagPossition={FlagPosition.PREPEND} />
+        <LanguageSelector flagPossition={FlagPosition.PREPEND} extraClass="" />
       </div>
       <div className={WelcomeStyles.actionButton}>
         <Button


### PR DESCRIPTION
# Summary

A global class intended for the lang selector in settings was breaking the lang selector on the welcome modal at screen sizes <850px

Before
![image](https://github.com/user-attachments/assets/64166bab-50e9-46cc-9811-c5677bb04fc6)

After
![image](https://github.com/user-attachments/assets/9b294605-7834-413a-a419-6d9c2c9d9f0b)
