### PR TITLE
[FIX] Steam on macOS not launching

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,4 +1,5 @@
 {
+    "16GB of RAM": "16GB of RAM",
     "accessibility": {
         "actions_font_family_no_default": "Actions Font Family (Default: ",
         "all_tiles_in_color": "Show all game tiles in color",
@@ -26,7 +27,9 @@
         "status": "Status",
         "title": "This game includes anticheat software"
     },
+    "Apple Silicon M1 or above": "Apple Silicon M1 or above",
     "back_to_game": "Back to game",
+    "Be aware that not all games will work and even if they do, they may not run as expected": "Be aware that not all games will work and even if they do, they may not run as expected.",
     "box": {
         "cache-cleared": {
             "message": "HyperPlay cache cleared.",
@@ -558,6 +561,9 @@
         "message": "Login with your platform. You can login to more than one platform at the same time.",
         "old-mac": "Your macOS version is {{version}}. macOS 12 or newer is required to log in."
     },
+    "macOS 14": {
+        "0 or above": "macOS 14.0 or above"
+    },
     "message": {
         "sync": "Sync Complete",
         "unsync": "Unsync Complete"
@@ -839,6 +845,7 @@
         }
     },
     "Recent": "Played Recently",
+    "Recommended Specs for a better experience": "Recommended Specs for a better experience",
     "search": "Search for Games",
     "setting": {
         "adddesktopshortcuts": "Add desktop shortcuts automatically",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -29,7 +29,7 @@
     },
     "Apple Silicon M1 or above": "Apple Silicon M1 or above",
     "back_to_game": "Back to game",
-    "Be aware that not all games will work and even if they do, they may not run as expected": "Be aware that not all games will work and even if they do, they may not run as expected.",
+    "Be aware that not all games will work, and even if they do, they may not run as expected": "Be aware that not all games will work, and even if they do, they may not run as expected.",
     "box": {
         "cache-cleared": {
             "message": "HyperPlay cache cleared.",
@@ -497,7 +497,7 @@
             "INITIATED": "Add custom token request pending"
         }
     },
-    "If you wish to continue, be patient since it can take a few minutes to finish depending on your internet connection and system configuration;": "If you wish to continue, be patient since it can take a few minutes to finish depending on your internet connection and system configuration;",
+    "If you wish to continue, please be patient since it can take a few minutes to finish depending on your internet connection and system configuration": "If you wish to continue, please be patient since it can take a few minutes to finish depending on your internet connection and system configuration.",
     "import-game-folder": {
         "cta": "Import Game Folder",
         "dialog": {
@@ -845,7 +845,7 @@
         }
     },
     "Recent": "Played Recently",
-    "Recommended Specs for a better experience": "Recommended Specs for a better experience",
+    "Recommended specs for a better experience": "Recommended specs for a better experience",
     "search": "Search for Games",
     "setting": {
         "adddesktopshortcuts": "Add desktop shortcuts automatically",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -26,7 +26,6 @@
         "status": "Status",
         "title": "This game includes anticheat software"
     },
-    "At the end make sure to": "At the end make sure to",
     "back_to_game": "Back to game",
     "box": {
         "cache-cleared": {
@@ -232,6 +231,7 @@
         },
         "title_dm": "Download Manager"
     },
+    "Downloading": "Downloading {{percent}}%",
     "email_subscription": {
         "subtitle": "You’re now a part of our community, and we’re excited to share valuable updates and insights with you.",
         "title": "Thank you for subscribing!"
@@ -456,9 +456,6 @@
         "viewPortfolio": "View portfolio"
     },
     "HyperPlay": "",
-    "HyperPlay will download and start the Steam Setup for you": {
-        " Please follow Steam instructions on their installer;": "HyperPlay will download and start the Steam Setup for you. Please follow Steam instructions on their installer;"
-    },
     "HyperPlay will notify you once the installation is done;": "HyperPlay will notify you once the installation is done;",
     "hyperplayOverlay": {
         "chainRequest": {
@@ -539,6 +536,7 @@
         "path": "Select Install Path"
     },
     "Install Steam": "Install Steam",
+    "Installing": "Installing",
     "Installing Steam": "Installing Steam...",
     "Launch Steam": "Launch Steam",
     "Launching Steam": "Launching Steam...",
@@ -675,7 +673,6 @@
         "offline-retry-in": "Offline. Retrying in {{seconds}} seconds.",
         "retrying": "Retrying"
     },
-    "On first launch Steam will download the necessary files and will take a few minutes to finish and the login screen to appear;": "On first launch Steam will download the necessary files and will take a few minutes to finish and the login screen to appear;",
     "options": {
         "advanced": {
             "key": "Variable Name",
@@ -731,6 +728,7 @@
         "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "Please connect to the internet to access the stores": "",
+    "Please Wait": "Please Wait",
     "please-wait": "Please wait...",
     "profile": "Profile",
     "progress": "Progress",
@@ -1033,7 +1031,6 @@
         "warningMessage": "Side-loading a game is a feature intended for developers and experienced power users. Side-loading an installer that contains malware could compromise your computer and lead to theft of funds.",
         "warningTitle": "Important"
     },
-    "since it will block HyperPlay configuration until Steam is closed;": "",
     "status": {
         "installing": "Installing",
         "logging": "Logging In...",
@@ -1070,7 +1067,6 @@
     "two_col_table": {
         "save_hint": "Changes in this table are not saved automatically. Click the + button"
     },
-    "UNCHECK 'Run Steam'": "UNCHECK 'Run Steam'",
     "userselector": {
         "logging_out": "Logging out",
         "logIn": "Log in",

--- a/src/frontend/screens/Library/components/SteamInstall/SteamInstallDialog.tsx
+++ b/src/frontend/screens/Library/components/SteamInstall/SteamInstallDialog.tsx
@@ -43,6 +43,26 @@ const SteamInstallDialog: React.FC<SteamInstallDialogProps> = ({
         <ul>
           <li>
             {t(
+              'Recommended Specs for a better experience',
+              'Recommended Specs for a better experience'
+            )}
+            :
+          </li>
+          <ul>
+            <li>
+              {t('Apple Silicon M1 or above', 'Apple Silicon M1 or above')}
+            </li>
+            <li>{t('macOS 14.0 or above', 'macOS 14.0 or above')}</li>
+            <li>{t('16GB of RAM', '16GB of RAM')}</li>
+          </ul>
+          <li>
+            {t(
+              'Be aware that not all games will work and even if they do, they may not run as expected.',
+              'Be aware that not all games will work and even if they do, they may not run as expected.'
+            )}
+          </li>
+          <li>
+            {t(
               'If you wish to continue, be patient since it can take a few minutes to finish depending on your internet connection and system configuration;',
               'If you wish to continue, be patient since it can take a few minutes to finish depending on your internet connection and system configuration;'
             )}

--- a/src/frontend/screens/Library/components/SteamInstall/SteamInstallDialog.tsx
+++ b/src/frontend/screens/Library/components/SteamInstall/SteamInstallDialog.tsx
@@ -1,14 +1,26 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
+import { TFunction } from 'i18next'
 import { Button } from '@hyperplay/ui'
 import { Dialog } from 'frontend/components/UI/Dialog'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faSpinner } from '@fortawesome/free-solid-svg-icons'
+import { hasProgress } from 'frontend/hooks/hasProgress'
 
 interface SteamInstallDialogProps {
   isInstalling: boolean
   onClose: () => void
   onInstall: () => void
+}
+
+const getProgressMessage = (percent: number, t: TFunction) => {
+  if (!percent) {
+    return t('Please Wait', 'Please Wait')
+  }
+  if (percent > 95) {
+    return t('Installing', 'Installing')
+  }
+  return t('Downloading', 'Downloading {{percent}}%', {
+    percent: percent.toFixed(0)
+  })
 }
 
 const SteamInstallDialog: React.FC<SteamInstallDialogProps> = ({
@@ -17,6 +29,10 @@ const SteamInstallDialog: React.FC<SteamInstallDialogProps> = ({
   onInstall
 }) => {
   const { t } = useTranslation()
+  const { progress } = hasProgress('steam')
+
+  const percent = progress.percent ?? 0
+  const downloadMessage = getProgressMessage(percent, t)
 
   return (
     <Dialog showCloseButton={false} onClose={onClose}>
@@ -33,27 +49,8 @@ const SteamInstallDialog: React.FC<SteamInstallDialogProps> = ({
           </li>
           <li>
             {t(
-              'HyperPlay will download and start the Steam Setup for you. Please follow Steam instructions on their installer;',
-              'HyperPlay will download and start the Steam Setup for you. Please follow Steam instructions on their installer;'
-            )}
-          </li>
-          <li>
-            {t('At the end make sure to', 'At the end make sure to')}{' '}
-            <strong>{t("UNCHECK 'Run Steam'", "UNCHECK 'Run Steam'")}</strong>,{' '}
-            {t(
-              'since it will block HyperPlay configuration until Steam is closed;'
-            )}
-          </li>
-          <li>
-            {t(
               'HyperPlay will notify you once the installation is done;',
               'HyperPlay will notify you once the installation is done;'
-            )}
-          </li>
-          <li>
-            {t(
-              'On first launch Steam will download the necessary files and will take a few minutes to finish and the login screen to appear;',
-              'On first launch Steam will download the necessary files and will take a few minutes to finish and the login screen to appear;'
             )}
           </li>
         </ul>
@@ -66,7 +63,7 @@ const SteamInstallDialog: React.FC<SteamInstallDialogProps> = ({
           disabled={isInstalling}
         >
           {isInstalling ? (
-            <FontAwesomeIcon icon={faSpinner} spin />
+            <span>{downloadMessage}</span>
           ) : (
             t('Install Steam', 'Install Steam')
           )}

--- a/src/frontend/screens/Library/components/SteamInstall/SteamInstallDialog.tsx
+++ b/src/frontend/screens/Library/components/SteamInstall/SteamInstallDialog.tsx
@@ -70,7 +70,7 @@ const SteamInstallDialog: React.FC<SteamInstallDialogProps> = ({
           <li>
             {t(
               'HyperPlay will notify you once the installation is done;',
-              'HyperPlay will notify you once the installation is done;'
+              'HyperPlay will notify you once the installation is done.'
             )}
           </li>
         </ul>

--- a/src/frontend/screens/Library/components/SteamInstall/SteamInstallDialog.tsx
+++ b/src/frontend/screens/Library/components/SteamInstall/SteamInstallDialog.tsx
@@ -43,8 +43,8 @@ const SteamInstallDialog: React.FC<SteamInstallDialogProps> = ({
         <ul>
           <li>
             {t(
-              'Recommended Specs for a better experience',
-              'Recommended Specs for a better experience'
+              'Recommended specs for a better experience',
+              'Recommended specs for a better experience'
             )}
             :
           </li>

--- a/src/frontend/screens/Library/components/SteamInstall/SteamInstallDialog.tsx
+++ b/src/frontend/screens/Library/components/SteamInstall/SteamInstallDialog.tsx
@@ -57,8 +57,8 @@ const SteamInstallDialog: React.FC<SteamInstallDialogProps> = ({
           </ul>
           <li>
             {t(
-              'Be aware that not all games will work and even if they do, they may not run as expected.',
-              'Be aware that not all games will work and even if they do, they may not run as expected.'
+              'Be aware that not all games will work, and even if they do, they may not run as expected.',
+              'Be aware that not all games will work, and even if they do, they may not run as expected.'
             )}
           </li>
           <li>

--- a/src/frontend/screens/Library/components/SteamInstall/SteamInstallDialog.tsx
+++ b/src/frontend/screens/Library/components/SteamInstall/SteamInstallDialog.tsx
@@ -63,8 +63,8 @@ const SteamInstallDialog: React.FC<SteamInstallDialogProps> = ({
           </li>
           <li>
             {t(
-              'If you wish to continue, be patient since it can take a few minutes to finish depending on your internet connection and system configuration;',
-              'If you wish to continue, be patient since it can take a few minutes to finish depending on your internet connection and system configuration;'
+              'If you wish to continue, please be patient since it can take a few minutes to finish depending on your internet connection and system configuration.',
+              'If you wish to continue, please be patient since it can take a few minutes to finish depending on your internet connection and system configuration.'
             )}
           </li>
           <li>


### PR DESCRIPTION
Since Steam moved to a new version of CEF (Chromium), it broke completely when using through the Gaming porting toolkit.
I changed the Steam source to be the latest version of Steam with the old CEF, that still works fine, and since this is not a Installation setup anymore, needed to change how we install it and, with it, some dialogs needed to be changed as well.

![image](https://github.com/user-attachments/assets/c06b946e-304e-4195-ab3e-f5329a413a97)


![image](https://github.com/user-attachments/assets/caa21fd7-0b5c-4b74-a52b-d6c9bda72cac)


### HOW TO TEST

- Uninstall your Steam installation on macOS if you have it.
- Reinstall Steam using the Install Steam button on the library
- Launch Steam after installing it and login to see if it will work fine and load the library.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
