### PR TITLE
[Fix] Auto update track event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperplay",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "private": true,
   "main": "build/main/main.js",
   "homepage": "./",

--- a/src/backend/updater.ts
+++ b/src/backend/updater.ts
@@ -5,10 +5,10 @@ import { t } from 'i18next'
 import { configStore, icon, isLinux } from './constants'
 import { logError, logInfo, LogPrefix } from './logger/logger'
 import { isOnline } from './online_monitor'
-import { trackEvent } from './api/metrics'
 import { captureException } from '@sentry/electron'
 import { getFileSize } from './utils'
 import { ClientUpdateStatuses } from '@hyperplay/utils'
+import { trackEvent } from './metrics/metrics'
 // to test auto update on windows locally make sure you added the option "verifyUpdateCodeSignature": false
 // under build.win in package.json and also change the app version to an old one there
 


### PR DESCRIPTION
# Summary

Fixes sentry error 
`TypeError: Cannot read properties of undefined (reading 'invoke')`

which is due to ipcRenderer being undefined in the previously imported track event. This PR updates to call it directly in the metrics module