### PR TITLE
feat(install-modal): block access code usage until user is logged in

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -544,6 +544,10 @@
     },
     "Install Steam": "Install Steam",
     "Installing Steam": "Installing Steam...",
+    "installModal": {
+        "loginRequired": "Login Required",
+        "loginRequiredMessage": "You need to be logged into HyperPlay to enter your access code and install this game. "
+    },
     "Launch Steam": "Launch Steam",
     "Launching Steam": "Launching Steam...",
     "library": {

--- a/src/frontend/screens/Library/components/InstallModal/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/index.tsx
@@ -29,6 +29,8 @@ import ChannelNameSelection from 'frontend/components/UI/ChannelNameSelection'
 import gameRequiresAccessCodes from 'frontend/helpers/gameRequiresAccessCodes'
 import ModDialog from './ModDialog'
 import { AccessCodeInput } from 'frontend/components/UI/AccessCodeInput'
+import useAuthSession from 'frontend/hooks/useAuthSession'
+import { AlertCard } from '@hyperplay/ui'
 
 type Props = {
   appName: string
@@ -44,6 +46,7 @@ export default React.memo(function InstallModal({
   gameInfo = null
 }: Props) {
   const { platform } = useContext(ContextProvider)
+  const { isSignedIn } = useAuthSession()
 
   const [winePrefix, setWinePrefix] = useState('...')
   const [wineVersion, setWineVersion] = useState<WineInstallation>()
@@ -198,6 +201,23 @@ export default React.memo(function InstallModal({
     />
   )
 
+  let accessCodeContent = null
+
+  if (channelRequiresAccessCode && runner === 'hyperplay') {
+    if (!isSignedIn) {
+      accessCodeContent = (
+        <AlertCard
+          showClose={false}
+          title="Login Required"
+          message="You need to be logged into HyperPlay to enter your access code and install this game."
+          variant="warning"
+        />
+      )
+    } else {
+      accessCodeContent = accessCodeInput
+    }
+  }
+
   return (
     <div className="InstallModal">
       <Dialog
@@ -236,10 +256,7 @@ export default React.memo(function InstallModal({
                 gameInfo={gameInfo}
               />
             ) : null}
-            {runner === 'hyperplay' && channelRequiresAccessCode
-              ? accessCodeInput
-              : null}
-
+            {accessCodeContent}
             {hasWine ? (
               <WineSelector
                 winePrefix={winePrefix}

--- a/src/frontend/screens/Library/components/InstallModal/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/index.tsx
@@ -325,9 +325,7 @@ export default React.memo(function InstallModal({
                   gameInfo={gameInfo}
                 />
               ) : null}
-              {runner === 'hyperplay' && channelRequiresAccessCode
-                ? accessCodeInput
-                : null}
+              {accessCodeContent}
             </div>
             {hasWine ? (
               <WineSelector

--- a/src/frontend/screens/Library/components/InstallModal/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/index.tsx
@@ -31,6 +31,7 @@ import ModDialog from './ModDialog'
 import { AccessCodeInput } from 'frontend/components/UI/AccessCodeInput'
 import useAuthSession from 'frontend/hooks/useAuthSession'
 import { AlertCard } from '@hyperplay/ui'
+import { useTranslation } from 'react-i18next'
 
 type Props = {
   appName: string
@@ -45,6 +46,7 @@ export default React.memo(function InstallModal({
   runner,
   gameInfo = null
 }: Props) {
+  const { t } = useTranslation()
   const { platform } = useContext(ContextProvider)
   const { isSignedIn } = useAuthSession()
 
@@ -208,8 +210,11 @@ export default React.memo(function InstallModal({
       accessCodeContent = (
         <AlertCard
           showClose={false}
-          title="Login Required"
-          message="You need to be logged into HyperPlay to enter your access code and install this game."
+          title={t('installModal.loginRequired', 'Login Required')}
+          message={t(
+            'installModal.loginRequiredMessage',
+            'You need to be logged into HyperPlay to enter your access code and install this game. '
+          )}
           variant="warning"
         />
       )


### PR DESCRIPTION
<--- Put the description here --->

closes https://github.com/HyperPlay-Gaming/product-management/issues/719

### How to test

1. Add a game that requires access code (Revolon or Market Wars for example) to your library
2. Click install
3. Check that the login alert error is displayed if you're not logged in. On Market Wars it shows in the step 4 content.
![image](https://github.com/user-attachments/assets/430b6faf-1939-4f02-be65-c1412f794e65)
![image](https://github.com/user-attachments/assets/da3d0820-fbfd-4586-bf2d-15b9517804b6)
![image](https://github.com/user-attachments/assets/31ce91c5-bed9-4e7d-89c2-661bffeeea72)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
