### PR TITLE
[UI] renamed public alpha to a dynamic version number on the Store

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -454,7 +454,6 @@
             }
         },
         "otp": "One Time Passcode",
-        "publicAlpha": "Public Alpha",
         "Sync": "Sync",
         "syncing": "Syncing...",
         "turnAnalyticsOff": "Turn off",
@@ -517,9 +516,6 @@
     "importGameErrorMessageExecutable": "Game Executable not found, importing game is not possible",
     "importGameErrorTitle": "Import Game Error",
     "info": {
-        "hyperplay": {
-            "version": "HyperPlay Version"
-        },
         "save-sync": {
             "searching": "Trying to detect the correct save folder (click to cancel)"
         },

--- a/src/frontend/components/UI/AppVersion/index.tsx
+++ b/src/frontend/components/UI/AppVersion/index.tsx
@@ -18,15 +18,5 @@ export default function AppVersion() {
     })
   }, [])
 
-  return (
-    <div
-      className="body-sm"
-      style={{
-        color: 'var(--color-neutral-400)',
-        margin: 'var(--space-xl) 0px var(--space-md) 0px'
-      }}
-    >
-      {t('info.hyperplay.version', 'HyperPlay Version') + `: ${appVersion}`}
-    </div>
-  )
+  return <div>{appVersion}</div>
 }

--- a/src/frontend/components/UI/AppVersion/index.tsx
+++ b/src/frontend/components/UI/AppVersion/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react'
-import { useTranslation } from 'react-i18next'
 
 const storage = window.localStorage
 let lastVersion = storage.getItem('last_version')?.replaceAll('"', '')
@@ -8,7 +7,6 @@ if (lastVersion === undefined) {
 }
 
 export default function AppVersion() {
-  const { t } = useTranslation()
   const [appVersion, setAppVersion] = useState(lastVersion)
 
   useEffect(() => {

--- a/src/frontend/components/UI/TopNavBar/index.module.scss
+++ b/src/frontend/components/UI/TopNavBar/index.module.scss
@@ -37,10 +37,10 @@
 }
 
 .alphaBadge {
-  background-color: var(--color-tertiary-700);
-  padding: var(--space-3xs) var(--space-sm);
+  background-color: var(--color-secondary-700);
+  padding: var(--space-2xs) var(--space-sm);
   border-radius: var(--space-xs);
-  margin-left: var(--space-sm);
+  margin: var(--space-xs) var(--space-md);
 }
 
 .hpLogo {

--- a/src/frontend/components/UI/TopNavBar/index.tsx
+++ b/src/frontend/components/UI/TopNavBar/index.tsx
@@ -16,6 +16,7 @@ import {
 } from 'frontend/constants'
 import webviewNavigationStore from 'frontend/store/WebviewNavigationStore'
 import { extractMainDomain } from '../../../helpers/extract-main-domain'
+import AppVersion from '../AppVersion'
 
 const TopNavBar = observer(() => {
   const { t } = useTranslation()
@@ -63,8 +64,8 @@ const TopNavBar = observer(() => {
           className={styles.hpTextLogo}
         />
         <div className={styles.alphaBadge}>
-          <div className={`caption ${styles.alphaCaption}`}>
-            {t(`hyperplay.publicAlpha`, `Public Alpha`)}
+          <div className={`menu-item ${styles.alphaCaption}`}>
+            <AppVersion />
           </div>
         </div>
         <>

--- a/src/frontend/screens/Settings/sections/GeneralSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/GeneralSettings/index.tsx
@@ -17,7 +17,6 @@ import {
   UseDarkTrayIcon,
   WinePrefixesBasePath
 } from '../../components'
-import AppVersion from 'frontend/components/UI/AppVersion'
 import AutoLaunchHyperPlay from '../../components/AutoLaunchHyperPlay'
 
 export default function GeneralSettings() {
@@ -25,8 +24,6 @@ export default function GeneralSettings() {
 
   return (
     <>
-      <AppVersion />
-
       <div className="settingSubheader settingsSectionHeader title">
         {t('settings.navbar.general')}
       </div>


### PR DESCRIPTION
<--- Description --->
This is a small update on our version badge on the Store, changed from Alpha to a dynamic version number, and also removed the version number on the settings page as we will have this in a more prominent place now. 

---
## Before
![image](https://github.com/user-attachments/assets/61e542c7-f2bd-430e-8766-f0a85c4a77e7)


## After
![photo_2024-12-10_13-07-13](https://github.com/user-attachments/assets/0a5864ed-9545-4be9-bc73-1ac5b86d305b)



Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
