### PR TITLE
[Fix] Token gated games install/update

### DIFF
--- a/src/backend/api/library.ts
+++ b/src/backend/api/library.ts
@@ -164,3 +164,5 @@ export const installSteamWindows = async () =>
 
 export const importGameFolder = async (gameFolder: string) =>
   ipcRenderer.invoke('importGameFolder', gameFolder)
+
+export const requestSIWE = async () => ipcRenderer.invoke('requestSIWE')

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -843,6 +843,8 @@ ipcMain.handle(
   }
 )
 
+ipcMain.handle('requestSIWE', HyperPlayGameManager.requestSIWE)
+
 ipcMain.handle('getEpicGamesStatus', async () => isEpicServiceOffline())
 
 ipcMain.handle('getMaxCpus', () => cpus().length)

--- a/src/backend/storeManagers/hyperplay/games.ts
+++ b/src/backend/storeManagers/hyperplay/games.ts
@@ -1412,7 +1412,12 @@ async function createSiweMessage(signerAddress: string): Promise<SiweMessage> {
   const statementRes = await fetch(
     DEV_PORTAL_URL + 'api/v1/license_contracts/validate/get-nonce'
   )
-  const statement = String(statementRes?.body)
+  if (!statementRes.ok) {
+    const responseError = await statementRes.text()
+    throw new Error(`Failed to get nonce for SIWE message. ${responseError}`)
+  }
+  const nonce = await statementRes.text()
+  const statement = String(nonce)
 
   return new SiweMessage({
     domain,
@@ -1500,6 +1505,7 @@ export async function update(
         `Could not get SIWE sig for updating token gated game. ${err}`,
         LogPrefix.HyperPlay
       )
+      captureException(err)
     }
   }
 

--- a/src/backend/storeManagers/hyperplay/games.ts
+++ b/src/backend/storeManagers/hyperplay/games.ts
@@ -801,6 +801,7 @@ export async function install(
     modOptions
   }: InstallArgs
 ): Promise<InstallResult> {
+  console.log('installing game with siwe values ', siweValues)
   if (await resumeIfPaused(appName)) {
     return { status: 'done' }
   }

--- a/src/backend/storeManagers/hyperplay/games.ts
+++ b/src/backend/storeManagers/hyperplay/games.ts
@@ -802,7 +802,6 @@ export async function install(
     modOptions
   }: InstallArgs
 ): Promise<InstallResult> {
-  console.log('installing game with siwe values ', siweValues)
   if (await resumeIfPaused(appName)) {
     return { status: 'done' }
   }

--- a/src/backend/storeManagers/hyperplay/games.ts
+++ b/src/backend/storeManagers/hyperplay/games.ts
@@ -1417,12 +1417,11 @@ async function createSiweMessage(signerAddress: string): Promise<SiweMessage> {
     throw new Error(`Failed to get nonce for SIWE message. ${responseError}`)
   }
   const nonce = await statementRes.text()
-  const statement = String(nonce)
 
   return new SiweMessage({
     domain,
     address: signerAddress,
-    statement,
+    statement: nonce.replaceAll('"', ''),
     uri: origin,
     version: '1',
     chainId: 1

--- a/src/backend/storeManagers/hyperplay/games.ts
+++ b/src/backend/storeManagers/hyperplay/games.ts
@@ -101,6 +101,7 @@ import { getFlag } from 'backend/flags/flags'
 import { ipfsGateway } from 'backend/vite_constants'
 import { GlobalConfig } from 'backend/config'
 import { PatchingError } from './types'
+import { SiweMessage } from 'siwe'
 
 interface ProgressDownloadingItem {
   DownloadItem: DownloadItem
@@ -1398,6 +1399,47 @@ export async function launch(appName: string): Promise<boolean> {
   return launchGame(appName, getGameInfo(appName), 'hyperplay')
 }
 
+async function createSiweMessage(signerAddress: string): Promise<SiweMessage> {
+  const mainWindowUrl = getMainWindow()?.webContents.getURL()
+  if (mainWindowUrl === undefined) {
+    throw 'could not get main window url'
+  }
+  const url = new URL(mainWindowUrl)
+  const domain = url.host ? url.host : 'hyperplay'
+  const origin = url.origin.startsWith('file://')
+    ? 'file://hyperplay'
+    : url.origin
+
+  const statementRes = await fetch(
+    DEV_PORTAL_URL + 'api/v1/license_contracts/validate/get-nonce'
+  )
+  const statement = String(statementRes?.body)
+
+  return new SiweMessage({
+    domain,
+    address: signerAddress,
+    statement,
+    uri: origin,
+    version: '1',
+    chainId: 1
+  })
+}
+
+export async function requestSIWE() {
+  const providers = await import('@hyperplay/providers')
+  const signer = await providers.provider.getSigner()
+  const address = await signer.getAddress()
+  const siweMessage = await createSiweMessage(address)
+  const message = siweMessage.prepareMessage()
+  const signature = await signer.signMessage(message)
+
+  return {
+    message,
+    signature,
+    address
+  }
+}
+
 // TODO: Refactor to only replace updated files
 export async function update(
   appName: string,
@@ -1424,8 +1466,6 @@ export async function update(
     return { status: 'error' }
   }
 
-  const isMarketWars = gameInfo.account_name === 'marketwars'
-
   const {
     channels,
     install: { channelName, platform, install_size, install_path, executable }
@@ -1447,6 +1487,23 @@ export async function update(
     throw new Error('Channel name or platform not found')
   }
 
+  const channelRequiresToken = !!channels[channelName]?.license_config.tokens
+
+  if (channelRequiresToken && args?.siweValues === undefined) {
+    // request from frontend
+    if (args === undefined) {
+      args = {}
+    }
+    try {
+      args.siweValues = await requestSIWE()
+    } catch (err) {
+      logError(
+        `Could not get SIWE sig for updating token gated game. ${err}`,
+        LogPrefix.HyperPlay
+      )
+    }
+  }
+
   const newVersion = channels[channelName].release_meta.name
   const abortController = createAbortController(appName)
   const { status, error } = await applyPatching(
@@ -1454,6 +1511,8 @@ export async function update(
     newVersion,
     abortController.signal
   )
+
+  const isMarketWars = gameInfo.account_name === 'marketwars'
 
   if (status === 'abort') {
     logWarning(`Patching ${appName} aborted`, LogPrefix.HyperPlay)

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -477,6 +477,11 @@ interface AsyncIPCFunctions extends HyperPlayAsyncIPCFunctions {
   getQuestsForGame: (projectId: string) => Promise<Quest[]>
   installSteamWindows: () => Promise<void>
   isClientUpdating: () => Promise<ClientUpdateStatuses>
+  requestSIWE: () => Promise<{
+    message: string
+    signature: string
+    address: string
+  }>
 }
 
 // This is quite ugly & throws a lot of errors in a regular .ts file

--- a/src/frontend/helpers/library.ts
+++ b/src/frontend/helpers/library.ts
@@ -278,9 +278,14 @@ const updateGame = async (gameInfo: GameInfo) => {
     gameInfo?.channels?.[gameInfo.install.channelName ?? ''].license_config
       .tokens
   let siweValues = undefined
+  console.log(
+    'updating game handler channelRequiresTokens ',
+    channelRequiresTokens
+  )
   if (channelRequiresTokens) {
     siweValues = await signSiweMessage()
   }
+  console.log('updating game with siwe values ', siweValues)
   return gameUpdateState.updateGame({ ...gameInfo, siweValues })
 }
 
@@ -292,12 +297,17 @@ export const hyperPlayCategories = ['all', 'hyperplay']
 export { install, launch, repair, updateGame }
 
 export async function signSiweMessage(): Promise<SiweValues> {
+  console.log('sign siwe message enter')
   const signer = await getSigner()
   const address = await signer.getAddress()
+  console.log('signer addr ', address)
 
   const siweMessage = await createSiweMessage(address)
+  console.log('siwe message ', siweMessage)
   const message = siweMessage.prepareMessage()
+  console.log('message ', message)
   const signature = await signer.signMessage(message)
+  console.log('signature ', signature)
 
   return {
     message,

--- a/src/frontend/helpers/library.ts
+++ b/src/frontend/helpers/library.ts
@@ -274,14 +274,9 @@ const updateGame = async (gameInfo: GameInfo) => {
     gameInfo?.channels?.[gameInfo.install.channelName ?? ''].license_config
       .tokens
   let siweValues = undefined
-  console.log(
-    'updating game handler channelRequiresTokens ',
-    channelRequiresTokens
-  )
   if (channelRequiresTokens) {
     siweValues = await window.api.requestSIWE()
   }
-  console.log('updating game with siwe values ', siweValues)
   return gameUpdateState.updateGame({ ...gameInfo, siweValues })
 }
 

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -40,7 +40,6 @@ import { configStore } from 'frontend/helpers/electronStores'
 import { AlertCard, Button, Images } from '@hyperplay/ui'
 import DLCDownloadListing from './DLCDownloadListing'
 import { useEstimatedUncompressedSize } from 'frontend/hooks/useEstimatedUncompressedSize'
-import { signSiweMessage } from 'frontend/helpers/library'
 import styles from './index.module.scss'
 
 interface Props {
@@ -206,7 +205,7 @@ export default function DownloadDialog({
   async function handleInstall(path?: string) {
     let siweValues
     if (requiresToken) {
-      siweValues = await signSiweMessage()
+      siweValues = await window.api.requestSIWE()
     }
     backdropClick()
     // Write Default game config with prefix on linux

--- a/src/frontend/screens/Library/components/InstallModal/ModDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/ModDialog/index.tsx
@@ -10,7 +10,6 @@ import { configStore } from 'frontend/helpers/electronStores'
 import TextInputWithIconField from 'frontend/components/UI/TextInputWithIconField'
 import { Button, Images } from '@hyperplay/ui'
 import { install } from 'frontend/helpers'
-import { signSiweMessage } from 'frontend/helpers/library'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { useFlags } from 'launchdarkly-react-client-sdk'
 import { marketWarsLinksFallback } from './constants'
@@ -94,7 +93,7 @@ const ModDialog: React.FC<Props> = ({
     let siweValues
 
     if (requiresToken) {
-      siweValues = await signSiweMessage()
+      siweValues = await window.api.requestSIWE()
     }
 
     // Write Default game config with prefix on linux


### PR DESCRIPTION
# Summary

This PR fixes
- update of token gated games
- install of token gated games with non mm extension wallets

request siwe logic is moved to main process so that the request goes to the currently connected provider, not just the injected provider on the main window

closes https://github.com/HyperPlay-Gaming/product-management/issues/837

