### PR TITLE
[Fix] arm64 release gha

### DIFF
--- a/.github/workflows/release_macOS.yml
+++ b/.github/workflows/release_macOS.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
         with:
           version: 9
           standalone: ${{ runner.os == 'Windows' }}
@@ -78,6 +78,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
 
       - name: Reconfigure git to use HTTP authentication
         run: >


### PR DESCRIPTION
# Summary

arm64 release step is failing with `pnpm: command not found`

https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/actions/runs/12405186947/job/34631594238