### PR TITLE
[Fix] Invalid URL error and image caching

### DIFF
--- a/src/backend/images_cache.ts
+++ b/src/backend/images_cache.ts
@@ -18,12 +18,14 @@ export const initImagesCache = () => {
 }
 
 const getImageFromCache = (url: string) => {
-  const realUrl = url.replace('imagecache://', '')
+  let realUrl = url.replace('imagecache://', '')
   // digest of the image url for the file name
   const digest = createHash('sha256').update(realUrl).digest('hex')
   const cachePath = join(imagesCachePath, digest)
 
   if (!existsSync(cachePath) && realUrl.startsWith('http')) {
+    realUrl = realUrl.replace('https//', 'https://')
+    realUrl = realUrl.replace('http//', 'http://')
     // if not found, download in the background
     axios
       .get(realUrl, { responseType: 'stream' })


### PR DESCRIPTION
# Summary

URLs were being passed over file protocol like `https//gateway.valist.io/ipfs/bafybeig57jh3x3q2vlmctjsdkx6yx36n4uza2rsp373suwlzcs2bgxkpbe` without the colon.

This was causing axios to throw a `Invalid URL` unhandled error on every `CachedImage` component render. This also broke the image caching functionality at `imagesCachePath`.

See https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/1732 for more context on the original implementation.  

We may be able to use https://www.electronjs.org/docs/latest/api/command-line-switches#--disk-cache-sizesize, which was suggested here https://github.com/electron/electron/issues/7713, for the same use case in the future as well instead of a custom caching implementation.

Closes https://github.com/HyperPlay-Gaming/product-management/issues/866