### PR TITLE
[Fix] Remove Spaces from the Wine Prefix Folder

### DIFF
--- a/src/frontend/helpers/index.ts
+++ b/src/frontend/helpers/index.ts
@@ -119,8 +119,11 @@ function getProgress(progress: InstallProgress): number {
 }
 
 function removeSpecialcharacters(text: string): string {
-  const regexp = new RegExp(/[:|/|*|?|<|>|\\|&|{|}|%|$|@|`|!|™|+|'|"|®]/, 'gi')
-  return text.replaceAll(regexp, '')
+  const regexp = new RegExp(
+    /[:|/|*|?|<|>|\\|&|{|}|%|$|@|`|!|™|+|'|"|®|\s]/,
+    'gi'
+  )
+  return text.replaceAll(regexp, '').trim()
 }
 
 const getStoreName = (runner: Runner, other: string) => {


### PR DESCRIPTION
This should fix issues like we had with the Rat game.

### HOW TO TEST
- On Linux and macOS only
- Install the RAT RACE COMBAT game
- Try to run it using any compatibility layer version
- The game should launch

In the current release the game won't launch because there is a `space` at the end of the generated prefix folder.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
