### PR TITLE
[Fix] Overlay performance issues with MetaMask Extension

### DIFF
--- a/src/frontend/ExtensionManager/index.tsx
+++ b/src/frontend/ExtensionManager/index.tsx
@@ -42,8 +42,17 @@ const ExtensionManager = function () {
     rootRef.current?.close()
   }
 
+  /**
+   * @dev We remove the popup/notification windows from the overlay when it is hidden because
+   * there were performance issues with them running in the background while playing some games like Kokodi.
+   */
   if (isOverlay) {
-    return <ExtensionContents />
+    if (OverlayState.showOverlay){
+      return <ExtensionContents />
+    }
+    else {
+      return null
+    }
   }
 
   /* eslint-disable react/no-unknown-property */


### PR DESCRIPTION
# Summary

Some games like Kokodi had mouse glitch and other performance issues due to excessive MetaMask popup window processing in the background when the overlay was hidden.

Now we remove the popup/notification windows from the overlay while the overlay is hidden.

The tradeoff is there is a slight ~1 second load time before the user can use the MM extension or notification window after toggling the overlay on.

# Testing

