### PR TITLE
(feat) update on hover state the the store icons on library

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -59,6 +59,7 @@
         "yesCancel": "Yes, cancel"
     },
     "button": {
+        "add_to_library": "Add to library",
         "cancel": "Pause/Cancel",
         "continue": "Continue Download",
         "details": "Details",
@@ -229,5 +230,13 @@
         "settings": "Settings",
         "store": "Store Page",
         "verify": "Verify and Repair"
+    },
+    "tooltip": {
+        "installed_from_epic": "Installed from Epic Store",
+        "installed_from_gog": "Installed from GOG Store",
+        "installed_from_hyperplay": "Installed from HyperPlay Store",
+        "will_install_from_epic": "Will install from Epic Store",
+        "will_install_from_gog": "Will install from GOG Store",
+        "will_install_from_hyperplay": "Will install from HyperPlay Store"
     }
 }

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -384,10 +384,42 @@ const GameCard = ({
           alwaysShowInColor={allTilesInColor}
           store={runner}
           i18n={{
+            addedToLibrary: t(
+              'button.remove_from_library',
+              'Remove from library'
+            ),
+            notAddedToLibrary: t('button.add_to_library', 'Add to library'),
             logoTextTooltip: {
-              hyperplay: { installed: 'HyperPlay', notInstalled: 'HyperPlay' },
-              epic: { installed: 'Epic', notInstalled: 'Epic' },
-              gog: { installed: 'GOG', notInstalled: 'GOG' }
+              hyperplay: {
+                installed: t(
+                  'tooltip.installed_from_hyperplay',
+                  'Installed from HyperPlay Store'
+                ),
+                notInstalled: t(
+                  'tooltip.will_install_from_hyperplay',
+                  'Will install from HyperPlay Store'
+                )
+              },
+              epic: {
+                installed: t(
+                  'tooltip.installed_from_epic',
+                  'Installed from Epic Store'
+                ),
+                notInstalled: t(
+                  'tooltip.will_install_from_epic',
+                  'Will install from Epic Store'
+                )
+              },
+              gog: {
+                installed: t(
+                  'tooltip.installed_from_gog',
+                  'Installed from GOG Store'
+                ),
+                notInstalled: t(
+                  'tooltip.will_install_from_gog',
+                  'Will install from GOG Store'
+                )
+              }
             }
           }}
         />


### PR DESCRIPTION
## Description

This PR adds the tooltip for the Store icons in the Library that was added on hyperplay-ui before, now being rendered on the client. 

### How it will be now
![image](https://github.com/user-attachments/assets/78822a26-0e19-4177-bbce-8caf8b5985cf)






---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
