### PR TITLE
[Fix] Store page while game is extracting

### DIFF
--- a/src/backend/ipcHandlers/mods.ts
+++ b/src/backend/ipcHandlers/mods.ts
@@ -125,8 +125,6 @@ export async function prepareBaseGameForModding({
     extractService.on('canceled', () => {
       logInfo(`Canceled Extracting of base game file`, LogPrefix.HyperPlay)
 
-      process.noAsar = false
-
       cancelQueueExtraction()
       callAbortController(appName)
 

--- a/src/backend/services/ExtractZipServiceWorker.ts
+++ b/src/backend/services/ExtractZipServiceWorker.ts
@@ -1,0 +1,57 @@
+import { Worker } from 'node:worker_threads'
+import { extractOptions } from './types'
+import { EventEmitter } from 'node:events'
+import path from 'node:path'
+
+export class ExtractZipServiceWorker extends EventEmitter {
+  worker: Worker
+  initPromise: Promise<void>
+  #resolveInitPromise: () => void = () => {
+    console.error('resolve init promise not assigned!')
+  }
+
+  constructor(
+    zipFile: string,
+    destinationPath: string,
+    options?: extractOptions
+  ) {
+    super()
+    this.initPromise = new Promise((res) => {
+      this.#resolveInitPromise = res
+    })
+    const extractZipServicePath = path.join(
+      __dirname,
+      '../preload/ExtractZipService.js'
+    )
+    this.worker = new Worker(extractZipServicePath)
+
+    this.worker.on('message', (data) => {
+      if (data?.initEvent === 'INITIALIZED') {
+        this.worker.postMessage({
+          type: 'INIT',
+          zipFile,
+          destinationPath,
+          options
+        })
+        return
+      } else if (data?.initEvent === 'ZIP_SERVICE_INSTANTIATED') {
+        this.#resolveInitPromise()
+        return
+      }
+      const { eventType, args } = data
+      this.emit(eventType, ...args)
+    })
+  }
+
+  public cancel() {
+    this.worker.postMessage({ type: 'CANCEL' })
+  }
+
+  public pause(): void {
+    this.worker.postMessage({ type: 'PAUSE' })
+  }
+
+  async extract() {
+    this.worker.postMessage({ type: 'EXTRACT' })
+  }
+}

--- a/src/backend/services/types.ts
+++ b/src/backend/services/types.ts
@@ -1,0 +1,5 @@
+export type extractOptions = {
+  deleteOnEnd?: boolean
+}
+
+export type ExtractZipServiceCommand = 'INIT' | 'CANCEL' | 'PAUSE' | 'EXTRACT'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,7 +54,8 @@ const preloads = [
   'src/backend/proxy/providerPreload.ts',
   'src/backend/hyperplay_store_preload.ts',
   'src/backend/webview_style_preload.ts',
-  'src/backend/auth_provider_preload.ts'
+  'src/backend/auth_provider_preload.ts',
+  'src/backend/services/ExtractZipService.ts'
 ]
 
 export default defineConfig(({ mode }) => ({


### PR DESCRIPTION
# Summary

Runs the `ExtractZipService` in a worker thread b wrapping `ExtractZipService` with `ExtractZipServiceWrapper`

Key benefits:
- `process.noAsar` can be modified without affecting the main thread
- performance improvements since extraction maxes out the main thread core 

closes https://github.com/HyperPlay-Gaming/px-pm/issues/112