### PR TITLE
[FIx] Edge case where downloaded size is bigger than download size

### DIFF
--- a/src/frontend/components/UI/DownloadToastManager/index.tsx
+++ b/src/frontend/components/UI/DownloadToastManager/index.tsx
@@ -14,6 +14,7 @@ import DMQueueState from 'frontend/state/DMQueueState'
 import { isNotNative } from 'frontend/helpers/library'
 import { hasProgress } from 'frontend/hooks/hasProgress'
 import { useGameInfo } from 'frontend/hooks/useGameInfo'
+import { useEstimatedUncompressedSize } from 'frontend/hooks/useEstimatedUncompressedSize'
 
 export default function DownloadToastManager() {
   const [latestElement, setLatestElement] = useState<DMQueueElement>()
@@ -37,6 +38,7 @@ export default function DownloadToastManager() {
   const installedPlatform = currentElement?.params.platformToInstall
   const isExtracting = status === 'extracting'
   const isPatching = status === 'patching'
+  const isInstalling = status === 'installing'
   const { progress, etaInMs } = hasProgress(appName, isExtracting)
 
   let showPlayTimeout: NodeJS.Timeout | undefined = undefined
@@ -160,10 +162,16 @@ export default function DownloadToastManager() {
     return 'inProgress'
   }
 
+  const uncompressedSize = useEstimatedUncompressedSize(
+    platform,
+    installInfo?.manifest?.disk_size || 0,
+    installInfo?.manifest?.download_size || 0
+  )
+
   let adjustedDownloadedInBytes = downloadedMB * 1024 * 1024
-  const adjustedDownloadSizeInBytes = isExtracting
-    ? installInfo?.manifest.disk_size || 0
-    : installInfo?.manifest.download_size || 0
+  const adjustedDownloadSizeInBytes = isInstalling
+    ? installInfo?.manifest.download_size || 0
+    : uncompressedSize
 
   if (isExtracting) {
     if (adjustedDownloadedInBytes > adjustedDownloadSizeInBytes) {

--- a/src/frontend/components/UI/DownloadToastManager/index.tsx
+++ b/src/frontend/components/UI/DownloadToastManager/index.tsx
@@ -160,9 +160,16 @@ export default function DownloadToastManager() {
     return 'inProgress'
   }
 
-  const adjustedDownloadedInBytes = downloadedMB * 1024 * 1024
-  const adjustedDownloadSizeInBytes =
-    progress.totalSize || installInfo?.manifest.download_size || 0
+  let adjustedDownloadedInBytes = downloadedMB * 1024 * 1024
+  const adjustedDownloadSizeInBytes = isExtracting
+    ? installInfo?.manifest.disk_size || 0
+    : installInfo?.manifest.download_size || 0
+
+  if (isExtracting) {
+    if (adjustedDownloadedInBytes > adjustedDownloadSizeInBytes) {
+      adjustedDownloadedInBytes = adjustedDownloadSizeInBytes
+    }
+  }
 
   return (
     <Draggable>


### PR DESCRIPTION
This changes how we get the Download Size depending on the status, right now it uses download status for both install and extracting. 

It also adds a safeguard to the Download Toast so it won't show a Downloaded size bigger than Total Download Size. Might not be needed but it is 'just in case' since our numbers might not be precise sometimes.

### Current issue
![image](https://github.com/user-attachments/assets/5ced4dd6-a3ef-4c97-8f1a-264243c53193)
![image](https://github.com/user-attachments/assets/1e63e1c6-10fa-465a-a8a9-b14057c7ff58)

### Fixed
https://github.com/user-attachments/assets/dfc178a2-93d0-463a-b349-991159cdb7f9

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
