### PR TITLE
[FIX] Reload app due to extension only on app update 

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -719,20 +719,12 @@ ipcMain.once('frontendReady', async () => {
   logInfo('Frontend Ready', LogPrefix.Backend)
   const currentVersion = app.getVersion()
   const lastVersion = configStore.get('appVersion', '')
-  const walletStateIsConnected = configStore.get(
-    'walletState.isConnected',
-    false
-  )
 
   await initExtension(hpApi)
 
   // Only reload the app if a wallet is not connected
   // or the app version has changed
-  if (
-    !walletStateIsConnected ||
-    !lastVersion ||
-    lastVersion !== currentVersion
-  ) {
+  if (!lastVersion || lastVersion !== currentVersion) {
     logInfo(
       'App version changed and wallet connected, reloading to update MM',
       LogPrefix.Backend

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -2049,7 +2049,6 @@ ipcMain.handle(
  */
 
 // sends messages to renderer process through preload.ts callbacks
-
 backendEvents.on('walletConnected', function (accounts: string[]) {
   getMainWindow()?.webContents.send('walletConnected', accounts)
 })

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -2050,43 +2050,6 @@ ipcMain.handle(
  */
 
 // sends messages to renderer process through preload.ts callbacks
-backendEvents.on('walletConnected', function (accounts: string[]) {
-  getMainWindow()?.webContents.send('walletConnected', accounts)
-  // Store wallet connection state
-  configStore.set('walletState.isConnected', true)
-  if (accounts && accounts.length > 0) {
-    configStore.set('walletState.address', accounts[0])
-  }
-})
-
-backendEvents.on('walletDisconnected', function (code: number, reason: string) {
-  getMainWindow()?.webContents.send('walletDisconnected', code, reason)
-  // Update wallet connection state
-  configStore.set('walletState.isConnected', false)
-})
-
-backendEvents.on('connectionRequestRejected', function () {
-  getMainWindow()?.webContents.send('connectionRequestRejected')
-})
-
-backendEvents.on('chainChanged', function (chainId: number) {
-  getMainWindow()?.webContents.send('chainChanged', chainId)
-})
-
-backendEvents.on(
-  'accountsChanged',
-  function (accounts: string[], provider: PROVIDERS) {
-    getMainWindow()?.webContents.send('accountChanged', accounts, provider)
-    // Update wallet details in configStore
-    if (accounts && accounts.length > 0) {
-      configStore.set('walletState.address', accounts[0])
-      configStore.set('walletState.provider', provider)
-      configStore.set('walletState.isConnected', true)
-    } else {
-      configStore.set('walletState.isConnected', false)
-    }
-  }
-)
 
 backendEvents.on('walletConnected', function (accounts: string[]) {
   getMainWindow()?.webContents.send('walletConnected', accounts)

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -722,8 +722,7 @@ ipcMain.once('frontendReady', async () => {
 
   await initExtension(hpApi)
 
-  // Only reload the app if a wallet is not connected
-  // or the app version has changed
+  // Only reload the app if the app version has changed
   if (!lastVersion || lastVersion !== currentVersion) {
     logInfo(
       'App version changed and wallet connected, reloading to update MM',

--- a/src/common/types/electron_store.ts
+++ b/src/common/types/electron_store.ts
@@ -21,6 +21,7 @@ import { UserData } from 'common/types/gog'
 
 export interface StoreStructure {
   configStore: {
+    appVersion: string
     userHome: string
     userInfo: UserInfo
     games: {
@@ -43,6 +44,11 @@ export interface StoreStructure {
     'window-props': Electron.Rectangle
     settings: AppSettings
     skipVcRuntime: boolean
+    walletState: {
+      isConnected: boolean
+      address: string
+      provider: PROVIDERS
+    }
   }
   wineDownloaderInfoStore: {
     'wine-releases': WineVersionInfo[]

--- a/src/common/types/electron_store.ts
+++ b/src/common/types/electron_store.ts
@@ -44,11 +44,6 @@ export interface StoreStructure {
     'window-props': Electron.Rectangle
     settings: AppSettings
     skipVcRuntime: boolean
-    walletState: {
-      isConnected: boolean
-      address: string
-      provider: PROVIDERS
-    }
   }
   wineDownloaderInfoStore: {
     'wine-releases': WineVersionInfo[]


### PR DESCRIPTION
This is a new approach from #1249.

### AI Summary
This pull request includes several changes to the `src/backend/main.ts` and `src/common/types/electron_store.ts` files to handle app version updates and ensure proper functionality when the app version changes. The changes primarily focus on checking the app version and reloading the app if the version has changed.

### Handling app version updates:

* [`src/backend/main.ts`](diffhunk://#diff-859af3c776da914ebff60fa13adfc96e79d99ea563fe1e4e790de14656442accR473-R483): Added logic to compare the current app version with the stored version and log the change. If the app version has changed, the new version is stored.
* [`src/backend/main.ts`](diffhunk://#diff-859af3c776da914ebff60fa13adfc96e79d99ea563fe1e4e790de14656442accR720-R735): Added a check in the `ipcMain.once('frontendReady', async () => {` block to reload the app if the app version has changed.

### Type definitions:

* [`src/common/types/electron_store.ts`](diffhunk://#diff-1e663c824f2fa561f595dca3a54d1be51a0be527bf080539216372c5697b3d5bR24): Added `appVersion` to the `StoreStructure` interface to store the app version.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
