### PR TITLE
fix: filter quests by type before mapping for user playstreak queries

### DIFF
--- a/src/frontend/hooks/useGetQuestStates.ts
+++ b/src/frontend/hooks/useGetQuestStates.ts
@@ -37,13 +37,15 @@ export function useGetQuestStates({
   let getUserPlaystreakQueries: getUserPlaystreakQueryOptionsType[] = []
   if (isSignedIn) {
     getUserPlaystreakQueries =
-      quests?.map((quest) => ({
-        ...getUserPlaystreakQueryOptions(
-          quest.id,
-          window.api.getUserPlayStreak
-        ),
-        enabled
-      })) ?? []
+      quests
+        ?.filter((quest) => quest.type === 'PLAYSTREAK')
+        .map((quest) => ({
+          ...getUserPlaystreakQueryOptions(
+            quest.id,
+            window.api.getUserPlayStreak
+          ),
+          enabled
+        })) ?? []
   }
   const getUserPlaystreakQuery = useQueries({
     queries: getUserPlaystreakQueries


### PR DESCRIPTION
<--- Put the description here --->

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
