### PR TITLE
Revert "[FIX] Reload app due to extension only on app update  (#1261)"

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -470,17 +470,6 @@ if (!gotTheLock) {
 
     createInjectedProviderWindow()
 
-    const currentStoredVersion = configStore.get('appVersion', '')
-    const currentVersion = app.getVersion()
-
-    if (currentStoredVersion !== currentVersion) {
-      logInfo(
-        `App version changed from ${currentStoredVersion} to ${app.getVersion()}`,
-        LogPrefix.Backend
-      )
-      configStore.set('appVersion', currentVersion)
-    }
-
     const providerPreloadPath = path.join(
       __dirname,
       '../preload/providerPreload.js'
@@ -717,22 +706,10 @@ ipcMain.once('loadingScreenReady', () => {
 
 ipcMain.once('frontendReady', async () => {
   logInfo('Frontend Ready', LogPrefix.Backend)
-  const currentVersion = app.getVersion()
-  const lastVersion = configStore.get('appVersion', '')
-
   await initExtension(hpApi)
-
-  // Only reload the app if the app version has changed
-  if (!lastVersion || lastVersion !== currentVersion) {
-    logInfo(
-      'App version changed and wallet connected, reloading to update MM',
-      LogPrefix.Backend
-    )
-    // wait for mm SW to initialize
-    await wait(5000)
-    ipcMain.emit('reloadApp')
-  }
-
+  // wait for mm SW to initialize
+  await wait(5000)
+  ipcMain.emit('reloadApp')
   handleProtocol([openUrlArgument, ...process.argv])
   setTimeout(() => {
     logInfo('Starting the Download Queue', LogPrefix.Backend)

--- a/src/common/types/electron_store.ts
+++ b/src/common/types/electron_store.ts
@@ -21,7 +21,6 @@ import { UserData } from 'common/types/gog'
 
 export interface StoreStructure {
   configStore: {
-    appVersion: string
     userHome: string
     userInfo: UserInfo
     games: {


### PR DESCRIPTION
Failing this test case
1. launch hp
2. create mm ext wallet and connect
3. close hp
4. open hp
5. try to connect wallet but no connection is made