### PR TITLE
[Fix] Add action rejected check to set active wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperplay",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "private": true,
   "main": "build/main/main.js",
   "homepage": "./",

--- a/src/frontend/components/UI/QuestDetails/index.tsx
+++ b/src/frontend/components/UI/QuestDetails/index.tsx
@@ -138,6 +138,9 @@ export default function QuestDetails({
     const signature = await signMessageAsync({
       message
     })
+    if (String(signature).includes('code=ACTION_REJECTED')) {
+      throw signature
+    }
 
     return {
       message,


### PR DESCRIPTION
# Summary

We were returning an object on set active wallet sign rejection and sending {} to the api for signature causing InvalidSignature during the set active wallet flow

closes https://github.com/HyperPlay-Gaming/hyperplay-pm/issues/578