### PR TITLE
[Fix] Platform icon on sideload dialog

### DIFF
--- a/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
@@ -253,7 +253,7 @@ export default function SideloadDialog({
   function platformIcon() {
     if (appPlatform !== 'Browser') {
       const platformIcon = availablePlatforms.filter(
-        (p) => p.name === platformToInstall
+        (p) => p.name.toLowerCase() === platformToInstall.toLowerCase()
       )[0]?.icon
 
       return (


### PR DESCRIPTION
# Summary

"Linux" !== "linux" so this was returning undefined and throwing an error in the console