### PR TITLE
[Fix] Overlay alert banner close button

### DIFF
--- a/src/frontend/components/UI/QuestsViewer/index.tsx
+++ b/src/frontend/components/UI/QuestsViewer/index.tsx
@@ -31,6 +31,7 @@ export function QuestsViewer({ projectId: appName }: QuestsViewerProps) {
           'You are currently not logged in, play streak progress will not be tracked. Please exit the game and login to HyperPlay via the top-right dropdown to track progress.'
         )}
         variant="warning"
+        showClose={false}
       />
     )
   }


### PR DESCRIPTION
# Summary

update the not logged in alert in the overlay to match the quests page alert by not showing the close button since it is not dismissable

closes https://github.com/HyperPlay-Gaming/hyperplay-pm/issues/647
