### PR TITLE
task: comment out Phantom logo in WC card for future use

### DIFF
--- a/src/frontend/screens/Onboarding/walletSelection/WalletConnectIconsStack.tsx
+++ b/src/frontend/screens/Onboarding/walletSelection/WalletConnectIconsStack.tsx
@@ -15,10 +15,6 @@ const walletIcons = [
   },
   { title: 'Ronin Wallet', icon: <Images.RoninWallet key={'roninwallet'} /> },
   { title: 'Trust Wallet', icon: <Images.TrustWallet key={'trustwallet'} /> },
-  // {
-  //   title: 'Phantom Wallet',
-  //   icon: <Images.PhantomWallet key={'phantomwallet'} />
-  // },
   { title: 'OKX Wallet', icon: <Images.OKXWallet key={'okxwallet'} /> },
   { title: 'Sequence Wallet', icon: <SequenceIcon /> },
   {

--- a/src/frontend/screens/Onboarding/walletSelection/WalletConnectIconsStack.tsx
+++ b/src/frontend/screens/Onboarding/walletSelection/WalletConnectIconsStack.tsx
@@ -15,10 +15,10 @@ const walletIcons = [
   },
   { title: 'Ronin Wallet', icon: <Images.RoninWallet key={'roninwallet'} /> },
   { title: 'Trust Wallet', icon: <Images.TrustWallet key={'trustwallet'} /> },
-  {
-    title: 'Phantom Wallet',
-    icon: <Images.PhantomWallet key={'phantomwallet'} />
-  },
+  // {
+  //   title: 'Phantom Wallet',
+  //   icon: <Images.PhantomWallet key={'phantomwallet'} />
+  // },
   { title: 'OKX Wallet', icon: <Images.OKXWallet key={'okxwallet'} /> },
   { title: 'Sequence Wallet', icon: <SequenceIcon /> },
   {


### PR DESCRIPTION
Removed the Phantom wallet logo from the wallet connection modal (WC card). This cleans up the UI since Phantom is no longer supported.

Changes Made

Commented out Phantom wallet icon for future use
Updated WC card to no longer display Phantom logo
